### PR TITLE
Fetch and display ESI queue data on dashboard

### DIFF
--- a/back-end/api-stubs/dashboard.json
+++ b/back-end/api-stubs/dashboard.json
@@ -56,5 +56,7 @@
       "skillInTraining": null,
       "queue": null
     }
-  ]
+  ],
+  "mainCharacter": 95773199,
+  "loginParams": null
 }

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -14,6 +14,7 @@
     "cookie-session": "^2.0.0-alpha.2",
     "express": "^4.14.0",
     "knex": "^0.12.6",
+    "moment": "^2.17.1",
     "pug": "^2.0.0-beta6",
     "request": "^2.79.0",
     "sqlite3": "^3.1.8",

--- a/back-end/src/route/api/dashboard.js
+++ b/back-end/src/route/api/dashboard.js
@@ -2,50 +2,158 @@ const fs = require('fs');
 const path = require('path');
 const querystring = require('querystring');
 
-const dao = require('../../dao.js');
+const moment = require('moment');
 
+const dao = require('../../dao.js');
+const esi = require('../../esi.js');
+
+const STATIC = require('../../static-data').get();
 const CONFIG = require('../../config-loader').load();
 
+const SKILL_LEVEL_LABELS = ['0', 'I', 'II', 'III', 'IV', 'V'];
+
+const LOGIN_PARAMS = querystring.stringify({
+  'response_type': 'code',
+  'redirect_uri': 'http://localhost:8081/authenticate',
+  'client_id':  CONFIG.ssoClientId,
+  'scope': CONFIG.ssoScope.join(' '),
+  'state': '12345',
+});
+
+const STUB_OUTPUT = false;
 
 module.exports = function(req, res) {
-  let json =
-      JSON.parse(
-          fs.readFileSync(
-              path.join(__dirname, '../../../api-stubs/dashboard.json'),
-              'utf8'));
+  (STUB_OUTPUT
+    ? getStubOutput()
+    : getRealOutput(req.session.accountId))
+  .then(function(output) {
+    let space = req.query.pretty != undefined ? 2 : undefined;
 
-  json.loginParams = querystring.stringify({
-    'response_type': 'code',
-    'redirect_uri': 'http://localhost:8081/authenticate',
-    'client_id':  CONFIG.ssoClientId,
-    'scope': CONFIG.ssoScope.join(' '),
-    'state': '12345',
-  });
-
-  let accountId = req.session.accountId;
-
-  dao.builder('ownership')
-      .select('character.id', 'character.name', 'accessToken.needsUpdate')
-      .join('character', 'character.id', '=', 'ownership.character')
-      .join('accessToken', 'accessToken.character', '=', 'ownership.character')
-      .where('ownership.account', accountId)
-  .then(function(rows) {
-    for (let i = 0; i < rows.length; i++) {
-      let row = rows[i];
-      json.characters.unshift({
-        id: row.id,
-        name: row.name,
-        hasApiKey: !row.needsUpdate,
-        skillInTraining: null,
-        queue: null,
-      })
-    }
     res.type('json');
-    res.send(JSON.stringify(json));
+    res.send(JSON.stringify(  output, null, space));
   })
   .catch(function(err) {
     // TODO
     console.log('ERROR:', err);
-    res.send(err);
+    res.send(err.toString());
   });
+}
+
+function getStubOutput() {
+  let json = JSON.parse(
+      fs.readFileSync(
+          path.join(__dirname, '../../../api-stubs/dashboard.json'),
+          'utf8'));
+  json.loginParams = LOGIN_PARAMS;
+
+  return Promise.resolve(json);
+}
+
+function getRealOutput(accountId) {
+  let mainCharacter = null;
+  return Promise.resolve()
+  .then(function() {
+    return dao.builder('account')
+        .select('mainCharacter')
+        .where('id', '=', accountId)
+  })
+  .then(function(rows) {
+    mainCharacter = rows[0].mainCharacter;
+  })
+  .then(function() {
+    return dao.builder('ownership')
+      .select('character.id', 'character.name', 'accessToken.needsUpdate')
+      .join('character', 'character.id', '=', 'ownership.character')
+      .join('accessToken', 'accessToken.character', '=', 'ownership.character')
+      .where('ownership.account', accountId);
+  })
+  .then(function(rows) {
+    let workList = [];
+    for (let i = 0; i < rows.length; i++) {
+      let row = rows[i];
+      workList.push(
+        esi
+        .getForCharacter('characters/' + row.id + '/skillqueue/', row.id)
+        .then(function(response) {
+          let queueData = response.data;
+
+          return {
+            id: row.id,
+            name: row.name,
+            hasApiKey: !row.needsUpdate,
+            skillInTraining: getSkillInTraining(queueData),
+            queue: getQueue(queueData),
+          };
+        })
+      );
+    }
+    return Promise.all(workList);
+  })
+  .then(function(characters) {
+    return {
+      characters: characters,
+      loginParams: LOGIN_PARAMS,
+      mainCharacter: mainCharacter,
+    };
+  })
+}
+
+function getSkillInTraining(queueData) {
+  let skillInTraining = null;
+  if (queueData.length > 0) {
+    let skill0 = queueData[0];
+    let skillName = STATIC.SKILLS[skill0.skill_id].name;
+    let skillLevelLabel = SKILL_LEVEL_LABELS[skill0.finished_level];
+
+    skillInTraining = {
+      name: skillName + ' ' + skillLevelLabel,
+      progress: getProgress(skill0),
+      timeRemaining: getDurationString(skill0.finish_date),
+    }
+  }
+  return skillInTraining;
+}
+
+function getQueue(queueData) {
+  let queue = null;
+  if (queueData.length > 0) {
+    let finalSkill = queueData[queueData.length - 1];
+    queue = {
+      count: queueData.length,
+      timeRemaining: getDurationString(finalSkill.finish_date),
+    }
+  }
+  return queue;
+}
+
+function getProgress(skill) {
+  // There must be a better way to do this...
+
+  let pretrainedProgress = (skill.training_start_sp - skill.level_start_sp) /
+      (skill.level_end_sp - skill.level_start_sp);
+
+  let trainingStart = new Date(skill.start_date);
+  let trainedProgress = (new Date() - trainingStart) /
+      (new Date(skill.finish_date) - trainingStart);
+
+  return pretrainedProgress + trainedProgress * (1 - pretrainedProgress);
+}
+
+function getDurationString(timestr) {
+  // There must be a better way....
+  let daysRemaining =
+        moment(timestr).diff(moment(), 'days', true);
+  let hoursRemaining = 24 * (daysRemaining - Math.floor(daysRemaining));
+  let minsRemaining = 60 * (hoursRemaining - Math.floor(hoursRemaining));
+  let timeRemaining;
+  if (daysRemaining >= 1) {
+    timeRemaining =
+        Math.floor(daysRemaining) + 'd ' + Math.round(hoursRemaining) + 'h';
+  } else if (hoursRemaining >= 1) {
+    timeRemaining =
+        Math.floor(hoursRemaining) + 'h ' + Math.round(minsRemaining) + 'm';
+  } else {
+    timeRemaining = Math.round(minsRemaining) + 'm';
+  }
+  return timeRemaining;
 }

--- a/back-end/src/route/authenticate.js
+++ b/back-end/src/route/authenticate.js
@@ -4,6 +4,7 @@ const request = require('request');
 
 const configLoader = require('../config-loader');
 const dao = require('../dao');
+const esi = require('../esi');
 
 
 const CONFIG = configLoader.load();
@@ -55,7 +56,7 @@ function handleAccessToken(req, res, body) {
   .then(function(response) {
     console.log('VERIFY CHAR', response.data);
     characterId = response.data.CharacterID;
-    return getEsi('characters/' + characterId + '/', accessToken);
+    return esi.get('characters/' + characterId + '/', accessToken);
   })
   .then(function(response) {
     console.log('ESI CHAR', response.data);

--- a/front-end/src/dashboard/CharacterSlab.vue
+++ b/front-end/src/dashboard/CharacterSlab.vue
@@ -1,6 +1,7 @@
 <template>
 <div class="slab-root">
-  <div class="slab-main">
+  <div class="slab-main"
+      :class="{ 'main-character': isMain }">
     <eve-image :id="character.id" :size="105" type="Character" />
     <div class="body">
       <router-link
@@ -51,6 +52,8 @@ export default {
 
   props: {
     character: { type: Object, required: true },
+    isMain: { type: Boolean, required: true },
+    highlightMain: { type: Boolean, required: true },
     loginParams: { type: String, required: true },
   },
 
@@ -106,6 +109,10 @@ export default {
   background: #101010;
   height: 105px;
   display: flex;
+}
+
+.main-character {
+  border-color: #4a433b;
 }
 
 .body {

--- a/front-end/src/dashboard/Dashboard.vue
+++ b/front-end/src/dashboard/Dashboard.vue
@@ -6,10 +6,12 @@
       />
   <div class="title">Dashboard</div>
   <div class="characters-container">
-    <character-slab v-for="character in characters"
+    <character-slab v-for="character in sortedCharacters"
         class="slab"
         :character="character"
         :loginParams="loginParams"
+        :isMain="character.id == mainCharacter"
+        :highlightMain="sortedCharacters.length > 1"
         @setApiKey="onApiKeySet"
         />
     <div class="add-character" v-if="loginParams">
@@ -43,7 +45,23 @@ export default {
     return {
       characters: [],
       loginParams: null,
+      mainCharacter: null,
     };
+  },
+
+  computed: {
+    sortedCharacters: function() {
+      this.characters.sort((a, b) => {
+        if (a.id == this.mainCharacter) {
+          return a;
+        } else if (b.id == this.mainCharacter) {
+          return b;
+        } else {
+          return a.name.localeCompare(b.name);
+        }
+      });
+      return this.characters;
+    }
   },
 
   created: function() {
@@ -51,6 +69,7 @@ export default {
       .then((response) => {
         this.characters = response.data.characters;
         this.loginParams = response.data.loginParams;
+        this.mainCharacter = response.data.mainCharacter;
       })
       .catch((err) => {
         // TODO


### PR DESCRIPTION
Whenever the user loads the dashboard, we kick off ESI requests
for the queues of all of their registered characters. These are
then displayed when they all trickle in. We should probably cache
these eventually.