### PR TITLE
Add ACL protections for skills and skillQueue

### DIFF
--- a/back-end/bin/schema.js
+++ b/back-end/bin/schema.js
@@ -190,7 +190,8 @@ knex.transaction(function(trx) {
     .then(function() {
         return trx.schema.createTable('ownership', (table) => {
             table.integer('character').primary().references('character.id');
-            table.integer('account').references('account.id').notNullable();
+            table.integer('account')
+                .references('account.id').index().notNullable();
         });
     })
     .then(function() {

--- a/back-end/src/dao.js
+++ b/back-end/src/dao.js
@@ -145,6 +145,17 @@ Dao.prototype = {
     });
   },
 
+  getOwner(characterId) {
+    return this.builder('character')
+        .select('account.id')
+        .leftJoin('ownership', 'ownership.character', '=', 'character.id')
+        .leftJoin('account', 'account.id', '=', 'ownership.account')
+        .where('character.id', '=', characterId)
+    .then(([row]) => {
+      return row;
+    });
+  },
+
   setAccountMain: function(accountId, mainCharacterId) {
     return this.builder('account')
         .where({id: accountId})

--- a/back-end/src/error/NotFoundError.js
+++ b/back-end/src/error/NotFoundError.js
@@ -1,0 +1,5 @@
+const ExtendableError = require('./ExtendableError');
+
+class NotFoundError extends ExtendableError {
+}
+module.exports = NotFoundError;

--- a/back-end/src/route/api/api.js
+++ b/back-end/src/route/api/api.js
@@ -29,6 +29,7 @@ router.get('/*', function(req, res, next) {
 });
 
 router.get('/dashboard', require('./dashboard'));
+router.get('/dashboard/:id/queueSummary', require('./dashboard/queueSummary'));
 
 router.get('/roster', require('./roster'));
 

--- a/back-end/src/route/api/character/skills.js
+++ b/back-end/src/route/api/character/skills.js
@@ -3,33 +3,27 @@ const eve = require('../../../eve');
 
 const jsonEndpoint = require('../../../route-helper/jsonEndpoint');
 const getStub = require('../../../route-helper/getStub');
-const skillQueue = require('../../../data-source/skillQueue');
-const time = require('../../../util/time');
 
 const STATIC = require('../../../static-data').get();
 
 
-const CACHE_SOURCE = 'skills'
-const CACHE_DURATION = 1000 * 60 * 5; // 5 minutes
 const STUB_OUTPUT = false;
 
-module.exports = jsonEndpoint(function(req, res) {
+module.exports = jsonEndpoint(function(req, res, accountId, privs) {
   if (STUB_OUTPUT) {
     return Promise.resolve(getStub('character.skills.json'));
   }
 
   let characterId = req.params.id;
 
-  return Promise.all([
-    fetchQueue(characterId),
-    fetchSkills(characterId),
-  ])
-  .then(function([queue, skills]) {
-    return {
-      queue: queue,
-      skills: skills,
-    };
-  });
+  return dao.getOwner(characterId)
+  .then(row => {
+    let owningAccount = row != null ? row.id : null;
+    privs.requireRead('characterSkills', accountId == owningAccount);
+  })
+  .then(() => {
+    return fetchSkills(characterId);
+  })
 });
 
 function fetchSkills(characterId) {
@@ -56,8 +50,9 @@ function fetchSkills(characterId) {
 }
 
 function fetchNewSkills(characterId) {
-  // TODO make the skill insertion into the table a tap, so that the fetchSkills() function doesn't have to
-  // requery them (although this would also involve reformatting the data here to match what DB would return)
+  // TODO make the skill insertion into the table a tap, so that the
+  // fetchSkills() function doesn't have to requery them (although this would
+  // also involve reformatting the data here to match what DB would return)
   return eve.getAccessToken(characterId)
     .then(accessToken => {
       return eve.esi.character.getSkills(characterId, accessToken);
@@ -87,42 +82,5 @@ function fetchNewSkills(characterId) {
             return trx.batchInsert('skillsheet', insertObjs, 100);
           });
       });
-  });
-}
-
-function fetchQueue(characterId) {
-  return skillQueue.getQueue(characterId)
-  .then(function(esiQueue) {
-    if (esiQueue.length == 0) {
-      return [];
-    }
-    let outQueue = [];
-
-    let now = new Date();
-    let queueEnd = new Date(esiQueue[esiQueue.length - 1].finish_date);
-    let totalDuration = queueEnd - now;
-
-    for (let i = 0; i < esiQueue.length; i++) {
-      let queueItem = esiQueue[i];
-      let skillId = queueItem.skill_id;
-
-      let skillStart = i == 0 ? now : new Date(queueItem.start_date);
-      let skillEnd = new Date(queueItem.finish_date);
-
-      let newItem = {
-        id: skillId,
-        proportionalStart: (skillStart - now) / totalDuration,
-        proportionalEnd: (skillEnd - now) / totalDuration,
-        durationLabel: time.shortDurationString(skillStart, skillEnd),
-        targetLevel: queueItem.finished_level,
-      };
-
-      if (i == 0) {
-        newItem.progress = skillQueue.getProgress(queueItem);
-      }
-
-      outQueue.push(newItem);
-    }
-    return outQueue;
   });
 }

--- a/back-end/src/route/api/dashboard/queueSummary.js
+++ b/back-end/src/route/api/dashboard/queueSummary.js
@@ -1,0 +1,59 @@
+const moment = require('moment');
+
+const dao = require('../../../dao');
+const jsonEndpoint = require('../../../route-helper/jsonEndpoint');
+const skillQueue = require('../../../data-source/skillQueue');
+const time = require('../../../util/time');
+
+
+const STATIC = require('../../../static-data').get();
+const SKILL_LEVEL_LABELS = ['0', 'I', 'II', 'III', 'IV', 'V'];
+
+module.exports = jsonEndpoint(function(req, res, accountId, privs) {
+  let characterId = req.params.id;
+
+  return dao.getOwner(characterId)
+  .then(row => {
+    let owningAccount = row != null ? row.id : null;
+    privs.requireRead('characterSkillQueue', accountId == owningAccount);
+  })
+  .then(() => {
+    return skillQueue.getQueue(characterId);
+  })
+  .then(queueData => {
+    return {
+      skillInTraining: getSkillInTraining(queueData),
+      queue: getQueue(queueData),
+    };
+  });
+});
+
+function getSkillInTraining(queueData) {
+  let skillInTraining = null;
+  if (queueData.length > 0) {
+    let skill0 = queueData[0];
+    let skillName = STATIC.SKILLS[skill0.skill_id].name;
+    let skillLevelLabel = SKILL_LEVEL_LABELS[skill0.finished_level];
+
+    skillInTraining = {
+      name: skillName + ' ' + skillLevelLabel,
+      progress: skillQueue.getProgress(skill0),
+      timeRemaining:
+          time.shortDurationString(Date.now(), skill0.finish_date, 2),
+    }
+  }
+  return skillInTraining;
+}
+
+function getQueue(queueData) {
+  let queue = null;
+  if (queueData.length > 0) {
+    let finalSkill = queueData[queueData.length - 1];
+    queue = {
+      count: queueData.length,
+      timeRemaining:
+          time.shortDurationString(Date.now(), finalSkill.finish_date, 2),
+    }
+  }
+  return queue;
+}

--- a/front-end/src/dashboard/CharacterSlab.vue
+++ b/front-end/src/dashboard/CharacterSlab.vue
@@ -112,7 +112,7 @@ export default {
   },
 
   created: function() {
-    ajaxer.getSkillQueue(this.character.id)
+    ajaxer.getSkillQueueSummary(this.character.id)
       .then(response => {
         this.queueFetchStatus = 'loaded';
         this.skillInTraining = response.data.skillInTraining;

--- a/front-end/src/shared/ajaxer.js
+++ b/front-end/src/shared/ajaxer.js
@@ -20,16 +20,20 @@ export default {
     return axios.get('/api/roster');
   },
 
-  fetchCharacter(id) {
+  getCharacter(id) {
     return axios.get('/api/character/' + id);
   },
 
-  fetchSkills(id) {
+  getSkills(id) {
     return axios.get('/api/character/' + id + '/skills');
   },
 
   getSkillQueue(id) {
     return axios.get('/api/character/' + id + '/skillQueue');
+  },
+
+  getSkillQueueSummary(id) {
+    return axios.get('/api/dashboard/' + id + '/queueSummary');
   },
 
   updatePilot(name, props) {


### PR DESCRIPTION
Also splits skills/skillqueue into separate endpoints and
moves the dashboard skillqueue endpoint to
/dashboard/:id/queueSummary.