### PR TITLE
Refactor tooltip to avoid reflows

### DIFF
--- a/front-end/src/admin/AccountLog.vue
+++ b/front-end/src/admin/AccountLog.vue
@@ -18,7 +18,7 @@
         <div class="cell event">{{ row.event }}</div>
         <div class="cell related-char">{{ row.relatedCharacterName }}</div>
         <div class="data">
-          <tooltip v-if="row.data" gravity="left" :packTarget="false">
+          <tooltip v-if="row.data" gravity="left bottom" :inline="false">
             <div class="cell">
               { ... }
             </div>

--- a/front-end/src/roster/CharacterRow.vue
+++ b/front-end/src/roster/CharacterRow.vue
@@ -37,7 +37,7 @@
         v-if="i >= 3"
         :style="cellStyle(i)"
         >
-      <tooltip gravity="right" :packTarget="false">
+      <tooltip gravity="right" inline:="false">
         {{ displayVal | dashDefault }}
         <span slot="message" v-if="tooltipMessage(i)"
             >{{ tooltipMessage(i) }}</span>

--- a/front-end/src/shared/LoadingSpinner.vue
+++ b/front-end/src/shared/LoadingSpinner.vue
@@ -13,7 +13,7 @@
           height: size + 'px',
         }"
         >
-    <span slot="message">{{ errorMessage }} </span>
+    <span slot="message" v-if="errorMessage != null">{{ errorMessage }} </span>
   </tooltip>
 
   <div class="block-message" v-if="status == 'error' && errorMode == 'text'">


### PR DESCRIPTION
Before we were reading the width and height of the hosting element
every time -- even if there was no tooltip to show. In pages with
many tooltips (like the roster), this was causing cascading reflow
calculations and was adding appreciable lag. Then I remembered that
flexbox is rad, and found a way to achieve the same effect without
the need for the JS. Woo, flexbox!