### PR TITLE
Modify syncKillboard to support partial executions

### DIFF
--- a/back-end/schema/007-killboard-table.js
+++ b/back-end/schema/007-killboard-table.js
@@ -1,0 +1,87 @@
+exports.up = function(knex, Promise) {
+  return knex.transaction(trx => {
+    return knex.raw('CREATE TEMPORARY TABLE tmp AS SELECT * FROM character')
+    .then(() => {
+      return knex.schema.dropTable('character');
+    })
+    .then(() => {
+      return knex.schema.createTable('character', (table) => {
+        table.integer('id').primary();
+        table.string('name').notNullable();
+        table.integer('corporationId').index();
+        table.string('titles').nullable();
+        table.bigInteger('startDate');
+        table.bigInteger('logonDate');
+        table.bigInteger('logoffDate');
+        table.integer('siggyScore');
+      });
+    })
+    .then(() => {
+      return knex.raw(`
+          INSERT INTO character
+              (id, name, corporationId, titles, startDate, logonDate, logoffDate, siggyScore)
+          SELECT id, name, corporationId, titles, startDate, logonDate, logoffDate, siggyScore
+          FROM tmp`);
+    })
+    .then(() => {
+      return knex.schema.createTable('killboard', (table) => {
+        table.integer('character').primary().references('character.id');
+        table.integer('killsInLastMonth');
+        table.integer('killValueInLastMonth');
+        table.integer('lossesInLastMonth');
+        table.integer('lossValueInLastMonth');
+        table.bigInteger('updated');
+      });
+    })
+    .then(() => {
+      return knex.raw(`
+          INSERT INTO killboard
+              (character, killsInLastMonth, killValueInLastMonth,
+              lossesInLastMonth, lossValueInLastMonth, updated)
+          SELECT id, killsInLastMonth, killValueInLastMonth, lossesInLastMonth,
+              lossValueInLastMonth, 0
+          FROM tmp`);
+    })
+    .then(() => {
+      return knex.schema.dropTable('tmp');
+    });
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.transaction(trx => {
+    return knex.raw('CREATE TEMPORARY TABLE tmp AS SELECT * FROM character')
+    .then(() => {
+      return knex.schema.dropTable('character');
+    })
+    .then(() => {
+      return knex.schema.createTable('character', (table) => {
+        table.integer('id').primary();
+        table.string('name').notNullable();
+        table.integer('corporationId').index();
+        table.string('titles').nullable();
+        table.bigInteger('startDate');
+        table.bigInteger('logonDate');
+        table.bigInteger('logoffDate');
+        table.integer('killsInLastMonth');
+        table.integer('killValueInLastMonth');
+        table.integer('lossesInLastMonth');
+        table.integer('lossValueInLastMonth');
+        table.integer('siggyScore');
+      });
+    })
+    .then(() => {
+      return knex.raw(`
+          INSERT INTO character
+              (id, name, corporationId, titles, siggyScore)
+          SELECT id, name, corporationId, titles, siggyScore
+          FROM tmp`);
+    })
+    .then(() => {
+      return knex.schema.dropTable('killboard');
+    })
+    .then(() => {
+      return knex.schema.dropTable('tmp');
+    });
+  });
+};

--- a/back-end/src/dao.js
+++ b/back-end/src/dao.js
@@ -31,10 +31,10 @@ const BASIC_CHARACTER_COLUMNS = [
   'character.startDate',
   'character.logonDate',
   'character.logoffDate',
-  'character.killsInLastMonth',
-  'character.killValueInLastMonth',
-  'character.lossesInLastMonth',
-  'character.lossValueInLastMonth',
+  'killboard.killsInLastMonth',
+  'killboard.killValueInLastMonth',
+  'killboard.lossesInLastMonth',
+  'killboard.lossValueInLastMonth',
   'character.siggyScore',
 ];
 const OWNED_CHARACTER_COLUMNS = BASIC_CHARACTER_COLUMNS.concat([
@@ -321,7 +321,8 @@ Dao.prototype = {
         .join('account', 'account.id', '=', 'memberAccount.id')
         .join('ownership', 'ownership.account', '=', 'memberAccount.id')
         .join('character', 'character.id', '=', 'ownership.character')
-        .leftJoin('citadel', 'citadel.id', '=', 'account.homeCitadel');
+        .leftJoin('citadel', 'citadel.id', '=', 'account.homeCitadel')
+        .leftJoin('killboard', 'killboard.character', '=', 'character.id');
   },
 
   getCharactersOwnedByAccount(accountId) {
@@ -339,6 +340,7 @@ Dao.prototype = {
     return this.builder('character')
         .select(BASIC_CHARACTER_COLUMNS)
         .leftJoin('ownership', 'ownership.character', '=', 'character.id')
+        .leftJoin('killboard', 'killboard.character', '=', 'character.id')
         .whereNull('ownership.account');
   },
 
@@ -425,7 +427,28 @@ Dao.prototype = {
         .limit(200);
   },
 
+  getCharacterKillboardTimestamps() {
+    return this.builder('character')
+        .select('character.id', 'character.name', 'killboard.updated')
+        .leftJoin('killboard', 'killboard.character', '=', 'character.id');
+  },
+
+  updateCharacterKillboard(characterId, kills, losses, killValue, lossValue) {
+    return this._upsert('killboard', {
+      character: characterId,
+      killsInLastMonth: kills,
+      killValueInLastMonth: killValue,
+      lossesInLastMonth: losses,
+      lossValueInLastMonth: lossValue,
+      updated: Date.now(),
+    }, 'character');
+  },
+
   _upsert(table, row, primaryKey) {
+    if (row[primaryKey] == undefined) {
+      throw new Error(`Primary key "${primaryKey}" not defined on input row.`);
+    }
+
     if (knex.CLIENT == 'sqlite3') {
       // Manually convert booleans to 0/1 for sqlite
       for (let v in row) {

--- a/back-end/src/util/asyncUtil.js
+++ b/back-end/src/util/asyncUtil.js
@@ -6,7 +6,7 @@ module.exports = {
    * Calls `callback(item, index)` on each item in `list`. Returns a Promise
    * wrapping all of the values returned by the callback calls.
    */
-  parallelize: function(list, callback) {
+  parallelize(list, callback) {
     let work = [];
 
     for (let i = 0; i < list.length; i++) {
@@ -20,7 +20,7 @@ module.exports = {
    * returns a `Promise`, waits until the promise resolves before calling
    * `callback` on the next item in the list.
    */
-  serialize: function(list, callback) {
+  serialize(list, callback) {
     let i = -1;
     let results = [];
 
@@ -45,4 +45,29 @@ module.exports = {
     });
   },
 
+  /**
+   * Repeatedly executes `callback` until it returns `undefined` (or a Promise
+   * that resolves to `undefined`). `callback` is passed the result of the
+   * previous execution. If this is the first execution, `initialValue` is
+   * passed instead.
+   */
+  doWhile(initialValue, callback) {
+    return new Promise((resolve, reject) => {
+      onResult(initialValue);
+
+      function onResult(previousResult) {
+        if (previousResult == undefined) {
+          resolve();
+        } else {
+          Promise.resolve(callback(previousResult))
+            .then(onResult)
+            .catch(onError);
+        }
+      }
+
+      function onError(e) {
+        reject(e);
+      }
+    });
+  },
 };


### PR DESCRIPTION
Mostly a quality-of-life change for devs who need to reboot the server
often. Allows cancelling a partially-executed killboard sync without
losing the work that was done.

- Shards the killboard stats off into their own table
- Each row has an "updated" timestamp. We skip updating any
rows that are sufficiently fresh.
- Killboard stats are saved to the DB immediately for each
character (instead of waiting for the complete fetch before saving).