### PR TITLE
Drop temporary tables when performing multiple migrations

### DIFF
--- a/back-end/schema/004-account-log-frontend.js
+++ b/back-end/schema/004-account-log-frontend.js
@@ -59,6 +59,9 @@ exports.up = function(knex, Promise) {
             { role: 'admin', privilege: 'accountLogs', level: 2 },
             { role: 'admin', privilege: 'cronLogs', level: 2 }
           ]);
+    })
+    .then(() => {
+      return knex.schema.dropTable('tmp');
     });
   });
 };
@@ -102,6 +105,9 @@ exports.down = function(knex, Promise) {
       return knex('rolePriv')
           .del()
           .whereIn('privilege', ['adminConsole', 'accountLogs', 'cronLogs']);
+    })
+    .then(() => {
+      return knex.schema.dropTable('tmp');
     });
   });
 };


### PR DESCRIPTION
The other migrations using a tmp temporary table already had these.