### PR TITLE
Don't require member role to switch mains

### DIFF
--- a/src/client/dashboard/CharacterSlab.vue
+++ b/src/client/dashboard/CharacterSlab.vue
@@ -173,8 +173,7 @@ export default {
 
     menuItems: function() {
       let items = [];
-      if (this.access.isMember &&
-          !this.isMain &&
+      if (!this.isMain &&
           this.access.designateMain == 2) {
         items.push({
           tag: 'designate-main',


### PR DESCRIPTION
This allows a member who is stuck with a "main" that's not in the main corp to switch mains and regain their roles.

I got into this state by merging accounts.  The merge was opposite of what I expected, and my actual main corp member was not my main, which suppressed the "designate as main" dropdown.