### PR TITLE
Move corp and siggy config into DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /static/dist/
 
 # Config files
-/config.local.json
+/config.local.json*
 
 # DB files
 /*.sqlite

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 3. `$ npm install`
 4. `$ cp config.local.json.example config.local.json`
 5. Edit `config.local.json` and fill in missing values
-6. `$ npm run updatedb`
+6. `$ node bin/updatedb.js`
 7. `$ npm start`
+8. Load up the site and log in with at least one character
+9. `$ node bin/quicksetup.js import config.local.json`
 
 ## Workflow
 

--- a/bin/quicksetup.js
+++ b/bin/quicksetup.js
@@ -1,0 +1,270 @@
+/**
+ * Script that automates most of the client-side server setup flow. Run with
+ * no arguments for usage instructions.
+ * 
+ * Do not use this in production.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const rjson = require('relaxed-json');
+
+const asyncUtil = require('../src/util/asyncUtil');
+const dao = require('../src/dao');
+const accountRoles = require('../src/data-source/accountRoles');
+const updateDbSchema = require('./updatedb');
+
+
+function main() {
+  let action = process.argv[2];
+
+  switch (action) {
+    case 'example':
+      console.log(EXAMPLE_INPUT);
+      break;
+    case 'import':
+      let path = process.argv[3];
+      path || die(`You must specify a filename to import`);
+      importConfig(path);
+      break;
+    default:
+      console.log(HELP);
+  }
+}
+
+function importConfig(filepath) {
+  let config;
+
+  return Promise.resolve()
+  .then(() => {
+    let absPath = path.resolve(filepath);
+    config = JSON.parse(rjson.transform(fs.readFileSync(absPath, 'utf8')));
+
+    verifyConfig(config);
+  })
+  .then(updateDbSchema)
+  .then(checkForAtLeastOneAccount)
+  .then(() => {
+    console.log('Importing config...');
+    return storeConfig(config);
+  })
+  .then(() => {
+    console.log('Config import complete.');
+    process.exit();    
+  })
+  .catch(e => {
+    console.error('ERROR!');
+    console.error(e);
+    die();
+  });
+}
+
+function verifyConfig(config) {
+  if (typeof config != 'object') {
+    die('Root element must be an object');
+  }
+
+  requireField(config, 'corporations', Array, false);
+  verifyCorporationsArray(config.corporations);
+
+  requireField(config, 'siggy', 'object', true);
+  if (config.siggy) {
+    requireField(config.siggy, 'username', 'string');
+    requireField(config.siggy, 'password', 'string');
+  }
+}
+
+function verifyCorporationsArray(config) {
+  let hasAtLeastOnePrimary = false;
+  for (let corp of config) {
+    verifyCorporation(corp);
+    hasAtLeastOnePrimary |= !!corp.primary;
+  }
+  if (!hasAtLeastOnePrimary) {
+    die('At least one corporation must be marked `primary: true`.');
+  }
+}
+
+function verifyCorporation(config) {
+  requireField(config, 'id', 'number', false);
+  requireField(config, 'keyId', 'number', false);
+  requireField(config, 'vCode', 'string', false);
+  requireField(config, 'id', Array, true);
+  requireField(config, 'primary', 'boolean', true);
+
+  for (let v in config.titles) {
+    if (typeof config.titles[v] != 'string') {
+      die(`Invalid role for title "${v}". must be a string.`);
+    }
+  }
+}
+
+function requireField(obj, varname, type, optional=false) {
+  let val = obj[varname];
+  if (val == undefined && optional) {
+    return;
+  }
+  if (val == undefined) {
+    die(`Missing required field "${varname}" in object `
+        + JSON.stringify(obj, null, 2));
+  }
+  if (typeof type == 'object') {
+    if (!(val instanceof type)) {
+      die(`Wrong type on field "${varname}". Required: ${type.name}. In object `
+          + JSON.stringify(obj, null, 2));
+    }
+  }
+  if (typeof type == 'string') {
+    if (typeof val != type) {
+      die(`Wrong type on field "${varname}". Required: ${type}. In object `
+          + JSON.stringify(obj, null, 2));
+    }
+  }
+}
+
+function checkForAtLeastOneAccount() {
+  console.log('Checking for account...');
+  return dao.builder('account').select().limit(1)
+  .then(rows => {
+    if (rows.length == 0) {
+      die('You must log in with at least one character first.');
+    }
+  });
+}
+
+function storeConfig(config) {
+  return dao.transaction(trx => {
+    return Promise.resolve()
+    .then(() => dropExistingCorpConfig(trx))
+    .then(() => 
+      asyncUtil.serialize(
+          config.corporations,
+          corpConfig => storeCorpConfig(trx, corpConfig)
+      )
+    )
+    .then(() => storeSiggyConfig(trx, config))
+    .then(() => setFirstAccountAsAdmin(trx));
+  });
+}
+
+function dropExistingCorpConfig(trx) {
+  return Promise.resolve()
+  .then(() => trx.builder('roleTitle').del())
+  .then(() => trx.builder('memberCorporation').del());
+}
+
+function storeCorpConfig(trx, corpConfig) {
+  return trx.builder('memberCorporation')
+      .insert({
+        corporationId: corpConfig.id,
+        apiKeyId: corpConfig.keyId,
+        apiVerificationCode: corpConfig.vCode,
+        membership: corpConfig.primary ? 'full' : 'affiliated',
+      })
+  .then(() => {
+    if (corpConfig.titles) {
+      let rows = [];
+      for (let [title, role] of Object.entries(corpConfig.titles)) {
+        rows.push({
+          corporation: corpConfig.id,
+          title: title,
+          role: role
+        });
+      }
+      return trx.builder('roleTitle')
+          .insert(rows);
+    }
+  });
+}
+
+function storeSiggyConfig(trx, config) {
+  if (config.siggy) {
+    return trx.setConfig({
+      'siggyUsername': config.siggy.username,
+      'siggyPassword': config.siggy.password,
+    });
+  }
+}
+
+function setFirstAccountAsAdmin(trx) {
+  return Promise.resolve()
+  .then(() => {
+    return trx.builder('roleExplicit')
+        .del()
+        .where('role', '=', '__admin');
+  })
+  .then(() => {
+    return trx.builder('account')
+        .select('account.id', 'character.name')
+        .join('character', 'character.id', '=', 'account.mainCharacter')
+        .whereNotNull('account.mainCharacter')
+        .orderBy('account.id')
+        .limit(1);
+  })
+  .then(([row]) => {
+    console.log(`Setting account ${row.id} (${row.name}) as admin...`);
+    return trx.builder('roleExplicit')
+        .insert({
+          account: row.id,
+          role: '__admin',
+        })
+    .then(() => {
+      return accountRoles.updateAccount(trx, row.id);
+    });
+  });
+}
+
+function die(message) {
+  console.error('FATAL: ' + message);
+  process.exit(2);
+}
+
+let HELP =
+`
+quicksetup
+Development tool for skipping the server setup flow in the client UI. Imports
+all of the relevant config info from a file. Overwrites any previous server
+configuration.
+
+Do not use this in production.
+
+Usage:
+$ node bin/quicksetup.js import <filename>  # Import a config file
+$ node bin/quicksetup.js example            # Print an example config file
+$ node bin/quicksetup.js help               # This message
+`
+
+let EXAMPLE_INPUT =
+`{
+  corporations: [
+    {
+      // SAFE
+      id: 98477920,
+      primary: true,
+      keyId: 977...,
+      vCode: "0n47ym3NN...",
+      titles: {
+        "Staff": "admin",
+        "Demi-dog": "admin",
+        "Official SOUND FC": "full_member",
+        "Junior SOUND FC": "limited_member"
+      }
+    },
+    {
+      // FRNT
+      id: 98477920,
+      primary: false,
+      keyId: 977...,
+      vCode: "0n47ym3NN...",
+      titles: {
+        "Barf": "space_dog",
+      }
+    },
+  ],
+  siggy: {
+    username: "spai",
+    password: "ronnie",
+  },
+}`;
+
+main();

--- a/bin/updatedb.js
+++ b/bin/updatedb.js
@@ -1,22 +1,25 @@
 /*
- * Command line tool for creating, updating, and/or migrating the roster database's schema.
- * After executing this script, the database sqlite file will be created if it did not exist, and
- * it will be up to date based on the schema migration definitions.
+ * Command line tool for creating, updating, and/or migrating the roster
+ * database's schema. After executing this script, the database sqlite file will
+ * be created if it did not exist, and it will be up to date based on the schema
+ * migration definitions.
  *
- * The optional argument --revert (or --rollback) can be used to undo the last applied batch of
- * schema scripts.
+ * The optional argument --revert (or --rollback) can be used to undo the last
+ * applied batch of schema scripts.
  *
- * Schema changes are stored in the ../schema/ directory and are applied in lexicographic order.
- * Due to this, all schema files should be named with a three digit prefix that provides a clear
- * ordering. When updated, all schema changes that haven't already been applied will be invoked.
- * This is tracked in a 'knex_migrations' table in the database and is based on the file name
- * (manual editing of this table may be necessary if the schema file needs to be renamed after
- * it has already been applied to a local database).
+ * Schema changes are stored in the ../schema/ directory and are applied in
+ * lexicographic order. Due to this, all schema files should be named with a
+ * three digit prefix that provides a clear ordering. When updated, all schema
+ * changes that haven't already been applied will be invoked. This is tracked in
+ * a 'knex_migrations' table in the database and is based on the file name
+ * (manual editing of this table may be necessary if the schema file needs to be
+ * renamed after it has already been applied to a local database).
  *
- * A schema change script must export an up and down function, both of which take a knex argument
- * and a Promise constructor. The up function is responsible for applying the schema, and the
- * down function manually rolls back the changes. Both of these functions are automatically invoked
- * inside a transaction. An empty example would look like:
+ * A schema change script must export an up and down function, both of which
+ * take a knex argument and a Promise constructor. The up function is
+ * responsible for applying the schema, and the down function manually rolls
+ * back the changes. Both of these functions are automatically invoked inside a
+ * transaction. An empty example would look like:
  *
  * ```
  * exports.up = function(knex, Promise) {
@@ -28,29 +31,18 @@
  * };
  * ```
  */
-
 const knex = require('../src/util/knex-loader');
+
+
 // Directory is relative to project root
-const migrateConfig = {
+const MIGRATE_CONFIG = {
   directory: './schema'
 };
 
-let revert = false;
-if (process.argv.length > 2) {
-  // Check if any remaining arguments are --revert or --rollback
-  for (let i = 2; i < process.argv.length; i++) {
-    if (process.argv[i] == '--revert' || process.argv[i] == '--rollback') {
-      revert = true;
-    } else {
-      console.warn('Ignoring unknown argument:', process.argv[i]);
-    }
-  }
-}
-
-
-if (revert) {
-  console.log('Reverting schema changes...');
-  knex.migrate.rollback(migrateConfig)
+const updateDb = module.exports = function(revert) {
+  if (revert) {
+    console.log('Reverting schema changes...');
+    return knex.migrate.rollback(MIGRATE_CONFIG)
     .then(function(reverts) {
       let batch = reverts[0];
       let scripts = reverts[1];
@@ -62,18 +54,11 @@ if (revert) {
       } else {
         console.log('No schema changes to roll back');
       }
-    })
-    .catch(function(error) {
-      console.error('Revert unsuccessful');
-      console.error(error);
-    })
-    .then(function() {
-      process.exit();
-    })
-} else {
-  // Proceed with an update to latest schema
-  console.log('Updating...');
-  knex.migrate.latest(migrateConfig)
+    });
+  } else {
+    // Proceed with an update to latest schema
+    console.log('Updating...');
+    return knex.migrate.latest(MIGRATE_CONFIG)
     .then(function(updates) {
       let batch = updates[0];
       let scripts = updates[1];
@@ -85,12 +70,31 @@ if (revert) {
       } else {
         console.log('Schema already up to date');
       }
-    })
-    .catch(function(error) {
-      console.error('Migration unsuccessful');
-      console.error(error);
-    })
-    .then(function() {
-      process.exit();
-    })
+    });
+  }
+}
+
+
+
+if (require.main == module) {
+  let revert = false;
+  if (process.argv.length > 2) {
+    // Check if any remaining arguments are --revert or --rollback
+    for (let i = 2; i < process.argv.length; i++) {
+      if (process.argv[i] == '--revert' || process.argv[i] == '--rollback') {
+        revert = true;
+      } else {
+        console.warn('Ignoring unknown argument:', process.argv[i]);
+      }
+    }
+  }
+
+  updateDb(revert)
+  .catch(function(error) {
+    console.error('Migration unsuccessful');
+    console.error(error);
+  })
+  .then(function() {
+    process.exit();
+  });
 }

--- a/config.local.json.example
+++ b/config.local.json.example
@@ -6,34 +6,6 @@
 
   "userAgent": "SOUND roster app / <character> (<email>) / <github url>"
 
-  "primaryCorporations": [
-    {
-      "id": 123456,
-      "keyId": 123456,
-      "vCode": "z8alsdALsd...lasdA0923"
-    }
-  ],
-
-  "altCorporations": [
-    {
-      "id": 123456,
-      "keyId": 123456,
-      "vCode": "z8alsdALsd...lasdA0923",
-      "titles": {
-        "Staff": "admin",
-        "Rocketstar": "full_member",
-        "Junior Rocketstar": "limited_member"
-      }
-    }
-  ],
-
-  // Uncomment and provide account name and password for siggy in order to
-  // scrap siggy stats. The account must be registered directly with siggy
-  // "siggy": {
-  //   "username": "<fillmein>",
-  //   "password": "<fillmein>"
-  // }
-
   // Force all requests to be handled as if the client's account had the
   // following roles. Set to [] to designate a client with no roles whatsoever.
   // "debugRoles": ["admin"],
@@ -44,4 +16,30 @@
 
   // Uncomment this to use stub output responses for routes, stored in api-stubs/
   // "useStubOutput": true,
+
+  "corporations": [
+    {
+      "id": 123456,
+      "primary": true,
+      "keyId": 123456,
+      "vCode": "z8alsdALsd...lasdA0923",
+      "titles": {
+        "Staff": "admin",
+        "Rocketstar": "full_member",
+        "Junior Rocketstar": "limited_member"
+      }
+    },
+    {
+      "id": 123456,
+      "keyId": 123456,
+      "vCode": "z8alsdALsd...lasdA0923"
+    }
+  ],
+
+  // Uncomment and provide account name and password for siggy in order to
+  // scrap siggy stats. The account must be registered directly with siggy
+  // "siggy": {
+  //   "username": "<fillmein>",
+  //   "password": "<fillmein>"
+  // }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "node-schedule": "^1.2.0",
     "path-to-regexp": "^1.7.0",
     "pug": "^2.0.0-beta6",
+    "relaxed-json": "^1.0.0",
     "scribe-js": "^2.0.4",
     "soupselect": "^0.2.0",
     "sqlite3": "^3.1.8",

--- a/schema/009-adjust-account-log.js
+++ b/schema/009-adjust-account-log.js
@@ -44,6 +44,7 @@ exports.down = function(knex, Promise) {
     })
     .then(() => {
       return knex.schema.createTable('accountLog', (table) => {
+        table.increments('id');
         table.bigInteger('timestamp').index().notNullable();
         table.integer('account').references('account.id').index().notNullable();
         table.enum('event', [

--- a/schema/010-corp-config.js
+++ b/schema/010-corp-config.js
@@ -1,0 +1,72 @@
+exports.up = function(knex, Promise) {
+  return knex.transaction(trx => {
+    return Promise.resolve()
+    .then(() => {
+      return knex.schema.createTable('memberCorporation', table => {
+        table.integer('corporationId').primary();
+        table.enum('membership', ['full', 'affiliated']).notNullable();
+        table.integer('apiKeyId').nullable();
+        table.string('apiVerificationCode').nullable();
+      });
+    })
+    .then(() => {
+      return knex.schema.createTable('roleTitle', table => {
+        table.integer('id').primary();
+        table.integer('corporation')
+            .references('memberCorporation.id')
+            .index()
+            .notNullable();
+        table.string('title').index().notNullable();
+        table.string('role').references('role.name').notNullable();
+
+        table.unique(['corporation', 'title', 'role']);
+      });
+    })
+    .then(() => {
+      return knex.schema.createTable('roleExplicit', table => {
+        table.integer('id').primary();
+        table.integer('account')
+            .references('account.id').index().notNullable();
+        table.string('role').references('role.name').notNullable();
+      });
+    })
+    .then(() => {
+      return knex.schema.createTable('config', table => {
+        table.string('key').primary();
+        table.text('value').nullable();
+        table.text('description').nullable();
+      });
+    })
+    .then(() => {
+      return knex('role')
+          .insert({
+            name: '__admin',
+          });
+    })
+    .then(() => {
+      return knex('config')
+          .insert([{
+            key: 'siggyUsername',
+            value: null,
+            description: 'Siggy username to use when scraping siggy stats.',
+          }, {
+            key: 'siggyPassword',
+            value: null,
+            description: null,
+          }]);
+    })
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.transaction(trx => {
+    return Promise.resolve()
+    .then(() => knex.schema.dropTable('roleExplicit'))
+    .then(() => knex.schema.dropTable('roleTitle'))
+    .then(() => knex.schema.dropTable('memberCorporation'))
+    .then(() => knex.schema.dropTable('config'))
+    .then(() => knex('role')
+        .del()
+        .where('name', '=', '__admin'))
+  });
+};

--- a/src/config-loader.js
+++ b/src/config-loader.js
@@ -8,7 +8,6 @@ const REQUIRED_CONFIGS = [
   'ssoClientId',
   'ssoSecretKey',
   'dbFileName',
-  'primaryCorporations',
 ];
 
 let loadedConfig = null;

--- a/src/cron/cron.js
+++ b/src/cron/cron.js
@@ -69,7 +69,6 @@ module.exports = {
 };
 
 function initTask(task) {
-  logger.info('Register task "%s"', task.name);
   return enqueueTaskIfOverdue(task)
   .then(() => {
     schedule.scheduleJob(task.schedule, function() {

--- a/src/route-helper/policy.js
+++ b/src/route-helper/policy.js
@@ -12,20 +12,5 @@ module.exports = {
     return Date.now() < accountCreated + MODIFY_MAIN_WINDOW_DURATION;
   },
 
-  corpStatus(corpId) {
-    if (_.findWhere(CONFIG.primaryCorporations, { id: corpId }) != null) {
-      return 'primary';
-    } else if (_.findWhere(CONFIG.altCorporations, { id: corpId }) != null) {
-      return 'alt';
-    } else {
-      return 'external';
-    }
-  },
-
-  isAffiliatedCorp(corpId) {
-    return (_.findWhere(CONFIG.primaryCorporations, { id: corpId }) != null) ||
-        (_.findWhere(CONFIG.altCorporations, { id: corpId }) != null);
-  },
-
   TIMEZONE_LABELS: ['US West', 'US East', 'EU West', 'EU East', 'Aus', 'Other'],
 };

--- a/src/route-helper/privileges.js
+++ b/src/route-helper/privileges.js
@@ -118,6 +118,9 @@ class AccountPrivileges {
     if (priv.requiresMembership && !this.isMember()) {
       effectiveLevel = 0;
     }
+    if (this.hasRole('__admin')) {
+      effectiveLevel = 2;
+    }
     this._precomputedLevels.set(key, effectiveLevel);
     return effectiveLevel;
   }

--- a/src/route/api/character/characterPut.js
+++ b/src/route/api/character/characterPut.js
@@ -21,7 +21,9 @@ function setIsOpsec(account, privs, characterId, isOpsec) {
   logger.debug('setIsOpsec', account, characterId, isOpsec);
   isOpsec = !!isOpsec;
 
-  return dao.getCharacterAndOwner(characterId, ['corporationId', 'account'])
+  return dao.getCharacterAndOwner(
+      characterId,
+      ['corporationId', 'account', 'membership'])
   .then(([row]) => {
     if (!row) {
       throw new BadRequestError(`Character not found: ${characterId}.`);
@@ -29,7 +31,7 @@ function setIsOpsec(account, privs, characterId, isOpsec) {
 
     privs.requireWrite('characterIsOpsec', account.id == row.account);
 
-    if (isOpsec && policy.isAffiliatedCorp(row.corporationId)) {
+    if (isOpsec && isMemberCorp(row.membership)) {
       throw new BadRequestError(
           `Cannot set character ${characterId} to opsec: character is in an ` +
           `affiliated corp (${row.corporationId})`);
@@ -37,4 +39,8 @@ function setIsOpsec(account, privs, characterId, isOpsec) {
 
     return dao.setCharacterIsOpsec(characterId, isOpsec);
   });
+}
+
+function isMemberCorp(membership) {
+  return membership == 'full' || membership == 'affiliated';
 }

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -1,5 +1,5 @@
 module.exports = {
   isProduction() {
     return process.env.NODE_ENV == 'production';
-  }
+  },
 };


### PR DESCRIPTION
As part of our dokku-ization, we're moving away from file-based
configs. This changes moves the list of "member" corporations as
well as the siggy credentials into the database.

As part of this, it also does the following:
- Creates a special "__admin" role. Accounts with this role have max
access on all permissions.
- Creates a way to explicitly assign roles to characters.
- Adds a new "quicksetup.js" script that will import setup from
config.local.json into the DB.
- Rejiggers updatedb script to allow it to be called
programmatically.

After this change, the process for setting up a dev server will be:
1. Start server
2. Log in
3. Run quicksetup.js script

These steps seem backwards, but the script needs at least one
account to exist so it can assign the "__admin" role to it.