### PR TITLE
Make quicksetup script work in Node LTS

### DIFF
--- a/bin/quicksetup.js
+++ b/bin/quicksetup.js
@@ -164,11 +164,11 @@ function storeCorpConfig(trx, corpConfig) {
   .then(() => {
     if (corpConfig.titles) {
       let rows = [];
-      for (let [title, role] of Object.entries(corpConfig.titles)) {
+      for (const title in corpConfig.titles) {
         rows.push({
           corporation: corpConfig.id,
           title: title,
-          role: role
+          role: corpConfig.titles[title]
         });
       }
       return trx.builder('roleTitle')


### PR DESCRIPTION
Current LTS is 6.10.0 which has very little ES2017 support.  Object.entries is behind a flag.

http://node.green/#ES2017-features-Object-static-methods-Object-entries

If we want to use ES2017 features, we'll have to investigate getting Dokku to use Node 7.6.0 or Node Nightly (!).