### PR TITLE
Ellipsize roster columns instead of wrapping

### DIFF
--- a/src/client/roster/CharacterRow.vue
+++ b/src/client/roster/CharacterRow.vue
@@ -259,6 +259,9 @@ function altsLabel(altsCount) {
   flex: 0 0 auto;
   color: #A7A29C;
   margin-left: 20px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .warning {


### PR DESCRIPTION
This is relevant for some citadel names, which are too long
to fit.