### PR TITLE
Use error name as default message for all custom errors

### DIFF
--- a/src/error/ExtendableError.js
+++ b/src/error/ExtendableError.js
@@ -2,11 +2,6 @@ module.exports = class ExtendableError extends Error {
   constructor(message) {
     super(message);
     this.name = this.constructor.name;
-    this.message = message; 
-    if (typeof Error.captureStackTrace === 'function') {
-      Error.captureStackTrace(this, this.constructor);
-    } else { 
-      this.stack = (new Error(message)).stack; 
-    }
+    this.message = message || this.name;
   }
 };


### PR DESCRIPTION
If `message` is null, Bluebird won't recognize our custom errors as
errors and will throw a warning.

Also removes some unneeded code from ExtendableError.