### PR TITLE
Update eve-swagger-js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cookie-parser": "^1.4.3",
     "cookie-session": "^2.0.0-alpha.2",
     "css-loader": "^0.26.2",
-    "eve_swagger_interface": "git://github.com/lhkbob/eve-swagger-js.git",
+    "eve-swagger": "^0.3.0",
     "express": "^4.14.0",
     "file-loader": "^0.10.1",
     "htmlparser": "^1.7.7",

--- a/src/eve.js
+++ b/src/eve.js
@@ -1,7 +1,7 @@
 const querystring = require('querystring');
 
 const axios = require('axios');
-const esi = require('eve_swagger_interface');
+const esi = require('eve-swagger');
 
 const MissingTokenError = require('./error/MissingTokenError');
 const dao = require('./dao');


### PR DESCRIPTION
Since this updates the dependencies, you'll need to rerun npm install, and may need to clean up the old eve_swagger_interface directory inside node_modules/