### PR TITLE
Store character skill queues, speed up dashboard

### DIFF
--- a/schema/020-add-skillqueue-table.js
+++ b/schema/020-add-skillqueue-table.js
@@ -1,0 +1,30 @@
+const Promise = require('bluebird');
+const migrate = require('./util/migrate');
+
+
+exports.up = migrate(trx => {
+  return Promise.resolve()
+  .then(() => {
+    return trx.schema.createTable('characterSkillQueue', table => {
+      table.integer('character').references('character.id').index();
+      table.integer('queuePosition').notNullable().index();
+      table.integer('skill').notNullable();
+      table.integer('targetLevel').notNullable();
+      table.bigInteger('startTime').nullable();
+      table.bigInteger('endTime').nullable();
+      table.integer('levelStartSp').notNullable();
+      table.integer('levelEndSp').notNullable();
+      table.integer('trainingStartSp').notNullable();
+
+      table.unique(['character', 'queuePosition']);
+      table.unique(['character', 'skill', 'targetLevel']);
+    });
+  });
+});
+
+exports.down = migrate(trx => {
+  return Promise.resolve()
+  .then(() => {
+    return trx.schema.dropTable('characterSkillQueue');
+  })
+});

--- a/src/client/assets/Dashboard-warning-icon.svg
+++ b/src/client/assets/Dashboard-warning-icon.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 43.2 (39069) - http://www.bohemiancoding.com/sketch -->
+    <title>warning-icon-centered</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="general" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M10.9862888,3.23019052 C11.5464093,2.28046498 12.454231,2.27993412 13.0146646,3.23019052 L23.1265173,20.3755808 C23.6866379,21.3253063 23.2477551,22.095211 22.1330764,22.095211 L1.86787699,22.095211 C0.759094188,22.095211 0.314002441,21.3258372 0.874436042,20.3755808 L10.9862888,3.23019052 Z M10.745253,19.2362314 L13.427108,19.2362314 L13.427108,17.5270083 L10.745253,17.5270083 L10.745253,19.2362314 Z M11.1892088,16.3367801 L12.9831523,16.3367801 L13.427108,11.0430324 L13.427108,8.99473269 L10.745253,8.99473269 L10.745253,11.0430324 L11.1892088,16.3367801 Z" id="Combined-Shape-Copy" fill="#A47A46"></path>
+    </g>
+</svg>

--- a/src/client/character/SkillSheet.vue
+++ b/src/client/character/SkillSheet.vue
@@ -138,10 +138,10 @@ export default {
             this.queue = queueResponse.data.queue;
             this.maybeInjectQueueDataIntoSkillsMap();
 
-            if (queueResponse.data.warning) {
+            if (queueResponse.data.dataStatus != 'fresh') {
               return {
                 state: 'warning',
-                message: queueResponse.data.warning,
+                message: 'Skill queue may be out of date',
               };
             }
           });

--- a/src/client/dashboard/Dashboard.vue
+++ b/src/client/dashboard/Dashboard.vue
@@ -2,14 +2,14 @@
 <div class="root">
   <app-header :identity="identity" />
   <div class="centering-container">
-  <div class="title">Dashboard</div>
-    <loading-spinner
-        class="main-spinner"
-        ref="spinner"
-        display="block"
-        defaultState="hidden"
-        size="34px"
-        />
+    <div class="title">
+      Dashboard
+      <loading-spinner
+          class="main-spinner"
+          ref="spinner"
+          defaultState="hidden"
+          />
+    </div>
     <div class="characters-container">
       <pending-transfer-slab v-for="transfer in transfers"
           class="slab"
@@ -41,6 +41,8 @@
 </template>
 
 <script>
+import _ from 'underscore';
+
 import ajaxer from '../shared/ajaxer';
 
 import AppHeader from '../shared/AppHeader.vue';
@@ -99,6 +101,7 @@ export default {
       this.loginParams = null;
       this.mainCharacter = null;
       this.access = null;
+
       this.$refs.spinner.observe(ajaxer.getDashboard())
       .then(response => {
         this.accountId = response.data.accountId;
@@ -107,6 +110,17 @@ export default {
         this.loginParams = response.data.loginParams;
         this.mainCharacter = response.data.mainCharacter;
         this.access = response.data.access;
+
+        return this.$refs.spinner.observe(ajaxer.getFreshSkillQueueSummaries());
+      })
+      .then(response => {
+        let freshSummaries = response.data;
+        for (let character of this.characters) {
+          let updatedEntry = _.findWhere(freshSummaries, { id: character.id });
+          if (updatedEntry) {
+            character.skillQueue = updatedEntry.skillQueue;
+          }
+        }
       });
     },
 
@@ -136,7 +150,7 @@ export default {
 }
 
 .main-spinner {
-  margin-left: 32px;
+  margin-left: 5px;
 }
 
 .characters-container {

--- a/src/client/dev/DevOwnedCharacterSlab.vue
+++ b/src/client/dev/DevOwnedCharacterSlab.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="_dev-owned-character-slap">
 
-  <div class="entry-title">Basic main</div>
+  <div class="entry-title">Main</div>
   <owned-character-slab
       :accountId="0"
       :character="characterBasic"
@@ -9,10 +9,9 @@
       :highlightMain="true"
       :loginParams="loginParams"
       :access="accessFull"
-      :isPuppet="true"
       />
 
-  <div class="entry-title">Basic alt</div>
+  <div class="entry-title">Alt</div>
   <owned-character-slab
       :accountId="0"
       :character="characterBasic"
@@ -20,7 +19,6 @@
       :highlightMain="true"
       :loginParams="loginParams"
       :access="accessFull"
-      :isPuppet="true"
       />
 
   <div class="entry-title">Opsec alt</div>
@@ -31,9 +29,35 @@
       :highlightMain="true"
       :loginParams="loginParams"
       :access="accessFull"
-      :isPuppet="true"
       />
   
+  <!-- Skill queue variations -->
+  <div class="section">Skill queue variations</div>
+
+  <div class="entry-title">Empty queue</div>
+  <owned-character-slab
+      :accountId="0"
+      :character="characterEmptyQueue"
+      :isMain="false"
+      :highlightMain="true"
+      :loginParams="loginParams"
+      :access="accessFull"
+      />
+
+  <div class="entry-title">Paused queue</div>
+  <owned-character-slab
+      :accountId="0"
+      :character="characterPausedQueue"
+      :isMain="false"
+      :highlightMain="true"
+      :loginParams="loginParams"
+      :access="accessFull"
+      />
+
+
+  <!-- Action handling -->
+  <div class="section">Action handling</div>
+
   <div class="entry-title">Action pending</div>
   <owned-character-slab
       ref="actionPendingSlab"
@@ -43,7 +67,6 @@
       :highlightMain="true"
       :loginParams="loginParams"
       :access="accessFull"
-      :isPuppet="true"
       />
 
   <div class="entry-title">Action failed</div>
@@ -55,7 +78,29 @@
       :highlightMain="true"
       :loginParams="loginParams"
       :access="accessFull"
-      :isPuppet="true"
+      />
+  
+  <div class="entry-title">ESI error</div>
+  <owned-character-slab
+      :accountId="0"
+      :character="characterUnfresQueue"
+      :isMain="true"
+      :highlightMain="true"
+      :loginParams="loginParams"
+      :access="accessFull"
+      />
+
+  <!-- Misc -->
+  <div class="section">Misc</div>
+
+  <div class="entry-title">Needs reauth (needs rework)</div>
+  <owned-character-slab
+      :accountId="0"
+      :character="characterNeedsReauth"
+      :isMain="false"
+      :highlightMain="true"
+      :loginParams="loginParams"
+      :access="accessFull"
       />
 </div>
 </template>
@@ -70,21 +115,12 @@ export default {
 
   data() {
     return {
-      characterBasic: {
-        id: 95773199,
-        name: 'Brienne Lesqagar',
-        needsReauth: false,
-        opsec: false,
-        corpStatus: 'primary',
-      },
-
-      characterOpsecAlt: {
-        id: 95773199,
-        name: 'Brienne Lesqagar',
-        needsReauth: false,
-        opsec: true,
-        corpStatus: 'external',
-      },
+      characterBasic: characterBasic(),
+      characterOpsecAlt: characterOpsec(),
+      characterNeedsReauth: characterNeedsReauth(),
+      characterEmptyQueue: characterBasic(emptySkillQueue()),
+      characterPausedQueue: characterBasic(pausedSkillQueue()),
+      characterUnfresQueue: characterBasic(unfreshSkillQueue()),
 
       accessFull: {
         isMember: true,
@@ -113,10 +149,91 @@ function errorPromise() {
   });
 }
 
+function characterBasic(skillQueue) {
+  return {
+    id: 95773199,
+    name: 'Brienne Lesqagar',
+    needsReauth: false,
+    opsec: false,
+    corpStatus: 'primary',
+    skillQueue: skillQueue || sampleSkillQueue(),
+  };
+}
+
+function characterOpsec() {
+  let character = characterBasic();
+  character.opsec = true;
+  character.corpStatus = 'external';
+  return character;
+}
+
+function characterNeedsReauth(skillQueue) {
+  let character = characterBasic(skillQueue);
+  character.needsReauth = true;
+  return character;
+}
+
+function sampleSkillQueue() {
+  return {
+    dataStatus: 'fresh',
+    queueStatus: 'active',
+    skillInTraining: {
+      name: 'Repair Systems V',
+      progress: 0.3886220453208478,
+      timeRemaining: '2d 1h'
+    },
+    queue: {
+      count: 4,
+      timeRemaining: '25d 14h'
+    }
+  };
+}
+
+function emptySkillQueue() {
+  return {
+    dataStatus: 'fresh',
+    queueStatus: 'empty',
+    skillInTraining: null,
+    queue: {
+      count: 0,
+      timeRemaining: null,
+    },
+  };
+}
+
+function pausedSkillQueue() {
+  return {
+    dataStatus: 'fresh',
+    queueStatus: 'paused',
+    skillInTraining: {
+      name: 'Gallente Frigate V',
+      progress: 0.17560084462264822,
+      timeRemaining: null,
+    },
+    queue: {
+      count: 6,
+      timeRemaining: null,
+    }
+  };
+}
+
+function unfreshSkillQueue() {
+  let queue = sampleSkillQueue();
+  queue.dataStatus = 'bad_credentials';
+  return queue;
+}
+
 </script>
 
 <style scoped>
 .entry-title {
-  margin: 30px 0 10px 0;
+  margin: 20px 0 10px 0;
+}
+
+.section {
+  font-size: 20px;
+  color: #a7a29c;
+  margin: 50px 0 5px 0;
+  font-weight: 300;
 }
 </style>

--- a/src/client/shared/ajaxer.js
+++ b/src/client/shared/ajaxer.js
@@ -82,8 +82,8 @@ export default {
     return axios.get('/api/character/' + id + '/skillQueue');
   },
 
-  getSkillQueueSummary(id) {
-    return axios.get('/api/dashboard/' + id + '/queueSummary');
+  getFreshSkillQueueSummaries() {
+    return axios.get('/api/dashboard/queueSummary');
   },
 
   getAdminAccountLog() {

--- a/src/dao.js
+++ b/src/dao.js
@@ -20,6 +20,7 @@ const asyncUtil = require('./util/asyncUtil');
 const accountGroups = require('./data-source/accountGroups');
 const knex = require('./util/knex-loader');
 const specialGroups = require('./route-helper/specialGroups')
+const CharacterDao = require('./dao/CharacterDao');
 const CitadelDao = require('./dao/CitadelDao');
 const ConfigDao = require('./dao/ConfigDao');
 const CronDao = require('./dao/CronDao');
@@ -66,6 +67,7 @@ const MEMBER_GROUP = accountGroups.MEMBER_GROUP;
 function Dao(builder) {
   this.builder = builder;
 
+  this.character = new CharacterDao(this, builder);
   this.citadel = new CitadelDao(this, builder);
   this.config = new ConfigDao(this, builder);
   this.cron = new CronDao(this, builder);

--- a/src/dao/CharacterDao.js
+++ b/src/dao/CharacterDao.js
@@ -1,0 +1,49 @@
+
+
+const CharacterDao = module.exports = class {
+  constructor(parent, builder) {
+    this._parent = parent;
+    this._builder = builder;
+  }
+
+  getCachedSkillQueue(characterId) {
+    return this._builder('characterSkillQueue')
+        .select(
+            'skill',
+            'targetLevel',
+            'startTime',
+            'endTime',
+            'levelStartSp',
+            'levelEndSp',
+            'trainingStartSp')
+        .where('character', '=', characterId)
+        .orderBy('queuePosition', 'asc');
+  }
+
+  setCachedSkillQueue(characterId, queueItems) {
+    return this._parent.transaction(trx => {
+      return Promise.resolve()
+      .then(() => {
+        return trx.builder('characterSkillQueue')
+            .del()
+            .where('character', '=', characterId);
+      })
+      .then(() => {
+        if (queueItems.length > 0) {
+          let items = queueItems.map((queueItem, index) => {
+            return Object.assign(
+                {
+                  character: characterId,
+                  queuePosition: index,
+                },
+                queueItem);
+          });
+          console.log('Storing!', items);
+          return trx.builder('characterSkillQueue')
+            .insert(items);
+        }
+      });
+    })
+  }
+
+}

--- a/src/data-source/skillQueue.js
+++ b/src/data-source/skillQueue.js
@@ -1,42 +1,161 @@
+const Promise = require('bluebird');
+const moment = require('moment');
+
+const errorUtil = require('../util/error');
 const eve = require('../eve');
+const logger = require('../util/logger')(__filename);
 
 module.exports = {
-  getQueue: function(characterId) {
-    return eve.getAccessToken(characterId)
-      .then(accessToken => {
-        return eve.esi.characters(characterId, accessToken).skillqueue();
-      })
-      .then(pruneCompletedSkills);
+  loadQueue(trx, characterId, freshness='fresh') {
+    if (freshness != 'cached' && freshness != 'fresh') {
+      throw new Error(`Illegal freshness argument: "${freshness}".`);
+    }
+
+    let status;
+    
+    return Promise.resolve()
+    .then(() => {
+      if (freshness == 'fresh') {
+        return getAndStoreEsiQueue(trx, characterId);
+      } else {
+        return 'cached';
+      }
+    })
+    .then(_status => {
+      status = _status;
+      return this.getCachedQueue(trx, characterId);
+    })
+    .then(skillQueue => {
+      return {
+        status: status,
+        queue: skillQueue,
+      };
+    });
   },
 
-  getProgress: function(queueEntry) {
-    // There must be a better way to do this...
+  getCachedQueue(trx, characterId) {
+    return Promise.resolve()
+    .then(() => {
+      return trx.character.getCachedSkillQueue(characterId);
+    })
+    .then(skillQueue => {
+      return pruneCompletedSkills(skillQueue);
+    });
+  },
 
-    let pretrainedProgress =
-        (queueEntry.training_start_sp - queueEntry.level_start_sp) /
-        (queueEntry.level_end_sp - queueEntry.level_start_sp);
+  getTrainingProgress(queueEntry) {
+    let pretrainedProgress = getProgressFraction(
+      queueEntry.levelStartSp,
+      queueEntry.levelEndSp,
+      queueEntry.trainingStartSp);
 
-    let trainingStart = new Date(queueEntry.start_date);
-    let trainedProgress = (new Date() - trainingStart) /
-        (new Date(queueEntry.finish_date) - trainingStart);
+    let trainedProgress = getProgressFraction(
+      queueEntry.startTime,
+      queueEntry.endTime,
+      Date.now());
 
     // Bound the result between 0 and 1, otherwise a skill that finished
     // since the last time a character logged in can show as > 100%
-    let fraction = pretrainedProgress + trainedProgress * (1 - pretrainedProgress);
-    return Math.min(Math.max(fraction, 0), 1);
+    trainedProgress = Math.min(1, Math.max(0, trainedProgress));
+
+    return pretrainedProgress
+        + trainedProgress * (1 - pretrainedProgress);
   },
+
+  getQueueStatus(queue) {
+    if (queue.length == 0) {
+      return 'empty';
+    } else if (queue[0].startTime == null) {
+      return 'paused';
+    } else {
+      return 'active';
+    }
+  }
 };
 
-function pruneCompletedSkills(queueData) {
-  // Why do we even need to DO this... #ccpls
-  let now = new Date();
-  let startIndex = 0;
-  for (let i = 0; i < queueData.length; i++) {
-    let endDate = new Date(queueData[i].finish_date);
-    if (endDate > now) {
-      break;
+function getAndStoreEsiQueue(trx, characterId) {
+  let status = 'fresh';
+
+  return Promise.resolve()
+  .then(() => {
+    return eve.getAccessToken(characterId)
+  })
+  .then(accessToken => {
+    return eve.esi.characters(characterId, accessToken).skillqueue();
+  })
+  .then(esiQueue => {
+    return trx.character.setCachedSkillQueue(
+        characterId,
+        convertEsiQueueToNativeQueue(esiQueue));
+  })
+  .catch(e => {
+    if (errorUtil.isAnyEsiError(e)) {
+      if (e.name == 'esi:ForbiddenError') {
+        status = 'bad_credentials';
+      } else {
+        status = 'fetch_failure';
+      }
+      logger.error(
+          `ESI error "${e.name}" while fetching skill queue for character`
+              + ` ${characterId}.`);
+      logger.error(e);
+    } else {
+      throw e;
     }
-    startIndex++;
+  })
+  .then(() => {
+    return status;
+  });
+}
+
+function convertEsiQueueToNativeQueue(esiQueue) {
+  esiQueue.sort((a, b) => {
+    if (a.queue_position < b.queue_position) {
+      return -1;
+    } else if (a.queue_position > b.queue_position) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
+  return esiQueue.map(qi => {
+    const nativeItem = {
+      skill: qi.skill_id,
+      targetLevel: qi.finished_level,
+      startTime: null,
+      endTime: null,
+      levelStartSp: qi.level_start_sp,
+      levelEndSp: qi.level_end_sp,
+      trainingStartSp: qi.training_start_sp,
+    };
+
+    if (qi.start_date != undefined && qi.finish_date != undefined) {
+      nativeItem.startTime = moment(qi.start_date).valueOf();
+      nativeItem.endTime = moment(qi.finish_date).valueOf();
+    }
+
+    return nativeItem;
+  });
+}
+
+function pruneCompletedSkills(queueData) {
+  let now = moment().valueOf();
+  let i = 0;
+  while (i < queueData.length
+      // Paused skill queues have items with null start times -- don't do any
+      // pruning for paused queues.
+      && queueData[i].startTime != null
+      && queueData[i].endTime < now) {
+    i++;
   }
-  return queueData.slice(startIndex);
+  return queueData.slice(i);
+}
+
+function getProgressFraction(start, end, current) {
+  if (start == null || end == null || end - start == 0) {
+    return 0;
+  } else {
+    return (current - start) / (end - start);
+  }
 }

--- a/src/route-helper/skillQueueSummarizer.js
+++ b/src/route-helper/skillQueueSummarizer.js
@@ -1,0 +1,69 @@
+const Promise = require('bluebird');
+
+const skillQueue = require('../data-source/skillQueue');
+const time = require('../util/time');
+
+const STATIC = require('../static-data').get();
+const SKILL_LEVEL_LABELS = ['0', 'I', 'II', 'III', 'IV', 'V'];
+
+/**
+ * Loads a character's skill queue and then generates summary text for it
+ * for use in the dashboard.
+ */
+module.exports = {
+  fetchSkillQueueSummary(trx, characterId, freshness='fresh') {
+    return skillQueue.loadQueue(trx, characterId, freshness)
+    .then(queueResult => {
+      let dataStatus = queueResult.status == 'cached' && freshness == 'cached'
+          ? 'cached-preview'
+          : queueResult.status;
+      let queueStatus = skillQueue.getQueueStatus(queueResult.queue);
+      return {
+        dataStatus: dataStatus,
+        queueStatus: queueStatus,
+        skillInTraining: getActiveSkillSummary(queueResult.queue, queueStatus),
+        queue: getQueueSummary(queueResult.queue, queueStatus),
+      };
+    });
+  },
+};
+
+function getQueueStatus(queue) {
+  if (queue.length == 0) {
+    return 'empty';
+  } else if (skillQueue.isQueuePaused(queue)) {
+    return 'paused';
+  } else {
+    return 'active';
+  }
+}
+
+function getActiveSkillSummary(queue, queueStatus) {
+  let summary = null;
+  if (queue.length > 0) {
+    let firstItem = queue[0];
+    let skillName = STATIC.SKILLS[firstItem.skill].name;
+    let skillLevelLabel = SKILL_LEVEL_LABELS[firstItem.targetLevel];
+
+    summary = {
+      name: skillName + ' ' + skillLevelLabel,
+      progress: skillQueue.getTrainingProgress(firstItem),
+      timeRemaining: queueStatus == 'active'
+          ? time.shortDurationString(Date.now(), firstItem.endTime, 2)
+          : null,
+    }
+  }
+  return summary;
+}
+
+function getQueueSummary(queue, queueStatus) {
+  return {
+    count: queue.length,
+    timeRemaining: queueStatus == 'active'
+        ? time.shortDurationString(
+            Date.now(),
+            queue[queue.length - 1].endTime,
+            2)
+        : null,
+  };
+}

--- a/src/route/api/api.js
+++ b/src/route/api/api.js
@@ -24,7 +24,7 @@ router.post('/account/:id/transfer', require('./account/transferCharacter'));
 router.delete('/account/:id/transfer/:charId', require('./account/deleteTransfer'));
 
 router.get('/dashboard', require('./dashboard'));
-router.get('/dashboard/:id/queueSummary', require('./dashboard/queueSummary'));
+router.get('/dashboard/queueSummary', require('./dashboard/queueSummary'));
 
 router.get('/roster', require('./roster'));
 

--- a/src/route/api/dashboard/queueSummary.js
+++ b/src/route/api/dashboard/queueSummary.js
@@ -1,69 +1,25 @@
-const moment = require('moment');
 const Promise = require('bluebird');
 
+const asyncUtil = require('../../../util/asyncUtil');
 const dao = require('../../../dao');
 const MissingAccessToken = require('../../../error/MissingTokenError');
 const protectedEndpoint = require('../../../route-helper/protectedEndpoint');
-const skillQueue = require('../../../data-source/skillQueue');
-const time = require('../../../util/time');
+const skillQueueSummarizer = require('../../../route-helper/skillQueueSummarizer');
 
-const STATIC = require('../../../static-data').get();
-const SKILL_LEVEL_LABELS = ['0', 'I', 'II', 'III', 'IV', 'V'];
 
 module.exports = protectedEndpoint('json', (req, res, account, privs) => {
-  let characterId = req.params.id;
-
-  return dao.getOwner(characterId)
-  .then(row => {
-    let owningAccount = row != null ? row.id : null;
-    privs.requireRead('characterSkillQueue', account.id == owningAccount);
-  })
-  .then(() => {
-    return skillQueue.getQueue(characterId);
-  })
-  .then(queueData => {
-    return {
-      skillInTraining: getSkillInTraining(queueData),
-      queue: getQueue(queueData),
-    };
-  })
-  .catch(err => {
-    if (err instanceof MissingAccessToken) {
-      return {
-        warning: 'Missing access token, queue unavailable.',
-      }
-    } else {
-      throw err;
-    }
-  })
+  return dao.getCharactersOwnedByAccount(account.id, [
+      'character.id',
+    ])
+  .then(rows => {
+    return asyncUtil.parallelize(rows, row => {
+      return skillQueueSummarizer.fetchSkillQueueSummary(dao, row.id, 'fresh')
+      .then(summary => {
+        return {
+          id: row.id,
+          skillQueue: summary,
+        };
+      });
+    });
+  });
 });
-
-function getSkillInTraining(queueData) {
-  let skillInTraining = null;
-  if (queueData.length > 0) {
-    let skill0 = queueData[0];
-    let skillName = STATIC.SKILLS[skill0.skill_id].name;
-    let skillLevelLabel = SKILL_LEVEL_LABELS[skill0.finished_level];
-
-    skillInTraining = {
-      name: skillName + ' ' + skillLevelLabel,
-      progress: skillQueue.getProgress(skill0),
-      timeRemaining:
-          time.shortDurationString(Date.now(), skill0.finish_date, 2),
-    }
-  }
-  return skillInTraining;
-}
-
-function getQueue(queueData) {
-  let queue = null;
-  if (queueData.length > 0) {
-    let finalSkill = queueData[queueData.length - 1];
-    queue = {
-      count: queueData.length,
-      timeRemaining:
-          time.shortDurationString(Date.now(), finalSkill.finish_date, 2),
-    }
-  }
-  return queue;
-}


### PR DESCRIPTION
This update takes advantage of the fact that people don't actually
change their skill queues that often. It makes the dashboard skill
queues now load ~semi-instantly.

- Whenever we load a character's skill queue, we now store it in the DB.
- When the dashboard first loads, we send our "cached" version of each
character's skill queue immediately.
- We then make a follow-up request that gets fresh versions from ESI and
update the dashboard if so (this turns out to be pretty rare).
- Instead of each character slab requesting its skill queue individually,
the dashboard now makes one large request that gets percolated down
to the slabs via their `character` object.