### PR TITLE
Enforce that all tnex queries are run()

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
     "**/node_modules": true,
     "**/bower_components": true,
     "**/out": true
-  }
+  },
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/schema/021-account-groups-unique.js
+++ b/schema/021-account-groups-unique.js
@@ -1,0 +1,42 @@
+const Promise = require('bluebird');
+const alterTable = require('./util/alterTable');
+const migrate = require('./util/migrate');
+
+exports.up = migrate(trx => {
+  return Promise.resolve()
+  .then(() => {
+    // We have too many duplicates; might as well drop the entire table
+    // and start over.
+    return trx.schema.dropTable('accountGroup');
+  })
+  .then(() => {
+    return trx.schema.createTable('accountGroup', table => {
+      table.integer('account')
+          .references('account.id')
+          .index()
+          .notNullable();
+      table.string('group')
+          .references('group.name')
+          .notNullable();
+      table.unique(['account', 'group']);
+    });
+  });
+});
+
+exports.down = migrate(trx => {
+  return Promise.resolve()
+  .then(() => {
+    return trx.schema.dropTable('accountGroup');
+  })
+  .then(() => {
+    return trx.schema.createTable('accountGroup', table => {
+      table.integer('account')
+          .references('account.id')
+          .index()
+          .notNullable();
+      table.string('group')
+          .references('group.name')
+          .notNullable();
+    });
+  });
+});

--- a/schema/util/migrate.js
+++ b/schema/util/migrate.js
@@ -1,5 +1,4 @@
 const Promise = require('bluebird');
-const asyncUtil = require('../../src/util/asyncUtil');
 
 
 module.exports = function migrate(fn) {
@@ -43,7 +42,7 @@ function runMigration(knex, fn) {
     .then(rows => {
       if (rows.length > 0) {
         console.error('FATAL: Foreign key violation(s) detected.')
-        return asyncUtil.serialize(rows, row => {
+        return Promise.each(rows, row => {
           return trx(row.table).select().where('rowid', '=', row.rowid)
           .then(sourceRows => {
             console.error('  Violation:', row);

--- a/src/dao/AccessTokenDao.ts
+++ b/src/dao/AccessTokenDao.ts
@@ -29,7 +29,8 @@ export default class AccessTokenDao {
       row: TokenUpdate) {
     return db
         .update(accessToken, row)
-        .where('accessToken_character', '=', val(characterId));
+        .where('accessToken_character', '=', val(characterId))
+        .run();
   }
 
   upsert(

--- a/src/dao/AccountDao.ts
+++ b/src/dao/AccountDao.ts
@@ -120,17 +120,6 @@ export default class AccountDao {
     });
   }
 
-  getGroups(db: Tnex, accountId: number) {
-    return db
-        .select(accountGroup)
-        .where('accountGroup_account', '=', db.val(accountId))
-        .columns('accountGroup_group')
-        .run()
-    .then(rows => {
-        return pluck(rows, 'accountGroup_group');
-    });
-  }
-
   setActiveTimezone(db: Tnex, accountId: number, timezone: string) {
     return db
         .update(account, { account_activeTimezone: timezone })
@@ -167,22 +156,26 @@ export default class AccountDao {
         .then(() => {
           return db
               .del(accountGroup)
-              .where('accountGroup_account', '=', val(accountId));
+              .where('accountGroup_account', '=', val(accountId))
+              .run();
         })
         .then(() => {
           return db
               .del(groupExplicit)
-              .where('groupExplicit_account', '=', val(accountId));
+              .where('groupExplicit_account', '=', val(accountId))
+              .run();
         })
         .then(() => {
           return db
               .del(pendingOwnership)
-              .where('pendingOwnership_account', '=', val(accountId));
+              .where('pendingOwnership_account', '=', val(accountId))
+              .run();
         })
         .then(() => {
           return db
               .del(account)
-              .where('account_id', '=', val(accountId));
+              .where('account_id', '=', val(accountId))
+              .run();
         })
         .then(() => {
           return 1;

--- a/src/dao/GroupsDao.ts
+++ b/src/dao/GroupsDao.ts
@@ -57,7 +57,8 @@ export default class GroupsDao {
         oldGroups = _oldGroups;
         return db
             .del(accountGroup)
-            .where('accountGroup_account', '=', val(accountId));
+            .where('accountGroup_account', '=', val(accountId))
+            .run();
       })
       .then(() => {
         if (groups.length > 0) {

--- a/src/route-helper/privileges.ts
+++ b/src/route-helper/privileges.ts
@@ -20,7 +20,7 @@ export function getPrivileges(db: Tnex, accountId: number) {
 
   return Promise.resolve()
   .then(() => {
-    return debugGroups || dao.account.getGroups(db, accountId);
+    return debugGroups || dao.group.getAccountGroups(db, accountId);
   })
   .then(_groups => {
     groups = _groups;

--- a/src/route/api/character.ts
+++ b/src/route/api/character.ts
@@ -103,7 +103,7 @@ export default jsonEndpoint((req, res, db, account, privs): Promise<Output> => {
   })
   .then(() => {
     if (accountId != null && privs.canRead('memberGroups')) {
-      return dao.account.getGroups(db, accountId)
+      return dao.group.getAccountGroups(db, accountId)
       .then(groups => {
         payload.account.groups = groups;
       });

--- a/src/tnex/Joiner.ts
+++ b/src/tnex/Joiner.ts
@@ -44,8 +44,10 @@ export class Joiner<J extends object /* joined */, S /* selected */>
       table: J,
       subqueryTableName?: string,
       ) {
-    super(scoper.mirror(), knex(scoper.getTableName(table)));
-
+    super(
+        scoper.mirror(),
+        knex(scoper.getTableName(table)),
+        subqueryTableName == undefined);
     this._subqueryTableName = subqueryTableName;
   }
 
@@ -53,8 +55,9 @@ export class Joiner<J extends object /* joined */, S /* selected */>
     if (this._subqueryTableName != null) {
       throw new Error(`Subqueries can't be run().`);
     }
+    this._query = this._query.select(this._getPendingColumnSelectStatements());
 
-    return this._query.select(this._getPendingColumnSelectStatements());
+    return super.run();
   }
 
   public fetchFirst(): Promise<S | null> {

--- a/src/tnex/Tnex.ts
+++ b/src/tnex/Tnex.ts
@@ -92,14 +92,16 @@ export class Tnex {
     return new Query<T, number>(
         this._registry,
         this._knex(this._registry.getTableName(table))
-            .update(this._prepForInsert(values, table)));
+            .update(this._prepForInsert(values, table)),
+        true);
   }
 
   public del<T extends object>(table: T): Query<T, number> {
     return new Query<T, number>(
         this._registry,
         this._knex(this._registry.getTableName(table))
-            .del());
+            .del(),
+        true);
   }
 
   public upsert<T extends object, R extends T>(


### PR DESCRIPTION
We were inserting an ever-increasing number of accountGroups
because of a missing .run() call at the end of a tnex chain.

- Adds code to crash if a tnex chain isn't finalized win run() or
fetchFirst()
- Fixes the accountGroup schema so that (account, group) uniqueness is
enforced.
- Fixes all existing areas that lack .run() calls.
- De-dupes a couple dao methods to get account groups
- Fixes problem matcher behavior in VS Code