### PR TITLE
Quick-and-dirty skill statistics

### DIFF
--- a/src/cron/cron.ts
+++ b/src/cron/cron.ts
@@ -39,6 +39,11 @@ const CRON_SCHEDULES: TaskSchedule[] = [
     interval: moment.duration(1, 'day').asMilliseconds(),
   },
   {
+    name: 'syncSkills',
+    schedule: '0 2 * * *',  // Once a day at 2AM
+    interval: moment.duration(1, 'day').asMilliseconds(),
+  },
+  {
     name: 'truncateCronLog',
     schedule: '0 0 */90 * *',  // Every 90 days
     interval: moment.duration(90, 'days').asMilliseconds(),

--- a/src/cron/task/syncSkills.ts
+++ b/src/cron/task/syncSkills.ts
@@ -1,0 +1,37 @@
+import Promise = require('bluebird');
+
+import { db as rootDb } from '../../db';
+import { dao } from '../../dao';
+import { Tnex } from '../../tnex';
+import { JobTracker, ExecutorResult } from '../Job';
+import { updateSkills } from '../../data-source/skills';
+import { MissingTokenError } from '../../error/MissingTokenError';
+import { isAnyEsiError } from '../../util/error';
+
+const logger = require('../../util/logger')(__filename);
+
+
+export function syncSkills(job: JobTracker): Promise<ExecutorResult> {
+  return dao.roster.getCharacterIdsOwnedByMemberAccounts(rootDb)
+  .then(characterIds => {
+    job.setProgress(0, undefined);
+
+    return Promise.each(characterIds, (characterId, i, len) => {
+      return updateSkills(rootDb, characterId)
+      .catch(MissingTokenError, e => {
+        logger.warn(`Missing access token for character ${characterId}, ` +
+            `skipping...`);
+      })
+      .catch(isAnyEsiError, e => {
+        logger.warn(`ESI error while fetching skills for char ${characterId}.`);
+        logger.warn(e);
+      })
+      .then(() => {
+        job.setProgress(i / len, undefined);
+      });
+    });
+  })
+  .then((): ExecutorResult => {
+    return 'success';
+  });
+}

--- a/src/cron/tasks.ts
+++ b/src/cron/tasks.ts
@@ -11,6 +11,7 @@ import { findWhere } from '../util/underscore';
 import { syncKillboard } from './task/syncKillboard';
 import { syncRoster } from './task/syncRoster';
 import { syncSiggy } from './task/syncSiggy';
+import { syncSkills } from './task/syncSkills';
 import { truncateCronLog } from './task/truncateCronLog';
 
 const logger = require('../util/logger')(__filename);
@@ -39,6 +40,13 @@ const TASKS: TaskInternal[] = [
     timeout: moment.duration(30, 'minutes').asMilliseconds(),
   },
   {
+    name: 'syncSkills',
+    displayName: 'Sync skills',
+    description: 'Updates all members\' skillsheets.',
+    executor: syncSkills,
+    timeout: moment.duration(30, 'minutes').asMilliseconds(),
+  },
+  {
     name: 'truncateCronLog',
     displayName: 'Truncate cron log',
     description: 'Prunes very old cron logs.',
@@ -51,6 +59,7 @@ export type TaskName =
     'syncRoster'
     | 'syncKillboard'
     | 'syncSiggy'
+    | 'syncSkills'
     | 'truncateCronLog'
     ;
 

--- a/src/dao.ts
+++ b/src/dao.ts
@@ -11,6 +11,7 @@ import OwnershipDao from './dao/OwnershipDao';
 import RosterDao from './dao/RosterDao';
 import SkillsheetDao from './dao/SkillsheetDao';
 import SkillQueueDao from './dao/SkillQueueDao';
+import StatisticsDao from './dao/StatisticsDao';
 
 
 export class Dao {
@@ -31,6 +32,7 @@ export class Dao {
   public roster = new RosterDao(this);
   public skillQueue = new SkillQueueDao(this);
   public skillsheet = new SkillsheetDao(this);
+  public statistics = new StatisticsDao(this);
 }
 
 export const dao = new Dao();

--- a/src/dao/CharacterDao.ts
+++ b/src/dao/CharacterDao.ts
@@ -122,13 +122,13 @@ export default class CharacterDao {
   }
 
   getMemberCharacters(db: Tnex) {
-      return db
-          .select(memberCorporation)
-          .join(character, 
-                'character_corporationId',
-                '=',
-                'memberCorporation_corporationId')
-          .columns('character_id', 'character_corporationId')
-          .run();
+    return db
+        .select(memberCorporation)
+        .join(character, 
+            'character_corporationId',
+            '=',
+            'memberCorporation_corporationId')
+        .columns('character_id', 'character_corporationId')
+        .run();
   }
 }

--- a/src/dao/StatisticsDao.ts
+++ b/src/dao/StatisticsDao.ts
@@ -1,0 +1,60 @@
+import Promise = require('bluebird');
+
+import { Tnex, val } from '../tnex';
+import { Dao } from '../dao';
+import { account, character, skillsheet, ownership,} from '../dao/tables';
+import { MEMBER_GROUP } from '../route-helper/specialGroups';
+
+export interface SkillRequirement {
+  skill: number,
+  minLevel: number,
+}
+
+export default class SkillQueueDao {
+  constructor(
+      private _parent: Dao,
+      ) {
+  }
+
+  getTrainedPercentage(db: Tnex, requirements: SkillRequirement[]) {
+    // The for-loop dynamism below means that we have to use the raw knex
+    // interface instead of Tnex :(
+
+    let knex = db.knex();
+
+    let query = knex('account')
+        .select(
+            'mainCharacter.id as id',
+            'mainCharacter.name as name',
+            'killboard.killsInLastMonth as kills')
+        .join(
+            // Subselect: all member accounts
+            knex.select('account.id')
+                .from('account')
+                .join('accountGroup',
+                    'accountGroup.account', '=', 'account.id')
+                .where('accountGroup.group', '=', MEMBER_GROUP)
+                .as('memberAccount'),
+            'memberAccount.id', '=', 'account.id')
+        .join('ownership', 'ownership.account', '=', 'account.id')
+        .join('character', 'character.id', '=', 'ownership.character')
+        .join('character as mainCharacter',
+            'mainCharacter.id', '=', 'account.mainCharacter')
+        .join('killboard', 'killboard.character', '=', 'mainCharacter.id')
+        .distinct('account.id')
+        .orderBy('killboard.killsInLastMonth', 'desc');
+
+    for (let i = 0; i < requirements.length; i++) {
+      let r = requirements[i];
+      let alias = `ss${i}`;
+
+      query = query
+          .join(`skillsheet as ${alias}`,
+              `${alias}.character`, '=', 'character.id')
+          .where(`${alias}.skill`, '=', r.skill)
+          .where(`${alias}.level`, '>=', r.minLevel)
+    }
+
+    return query;
+  }
+}

--- a/src/data-source/skills.ts
+++ b/src/data-source/skills.ts
@@ -1,0 +1,34 @@
+import { Tnex } from '../tnex';
+import { dao } from '../dao';
+
+import { getAccessTokenForCharacter } from './accessToken';
+import { default as esi } from '../esi';
+
+const logger = require('../util/logger')(__filename);
+
+
+/** Throws MissingTokenError and ESI failure errors. */
+export function updateSkills(db: Tnex, characterId: number) {
+  // TODO: Incorporate completed skills in skill queue here
+  return getAccessTokenForCharacter(db, characterId)
+  .then(accessToken => {
+    return esi.characters(characterId, accessToken).skills();
+  })
+  .then(data => {
+    return data.skills;
+  })
+  .then(esiSkills => {
+    logger.debug(`Inserting ${esiSkills.length} skills for character ` +
+        `${characterId}...`);
+    return db.transaction(db => {
+      return dao.skillsheet.set(db, characterId, esiSkills.map(esiSkill => {
+        return {
+          skillsheet_character: characterId,
+          skillsheet_skill: esiSkill.skill_id,
+          skillsheet_level: esiSkill.current_skill_level,
+          skillsheet_skillpoints: esiSkill.skillpoints_in_skill,
+        };
+      }))
+    });
+  });
+}

--- a/src/route/api/api.ts
+++ b/src/route/api/api.ts
@@ -25,6 +25,8 @@ import character_skills from './character/skills';
 import dashboard from './dashboard';
 import dashboard_queueSummary from './dashboard/queueSummary';
 
+import statistics_skills from './statistics/skills';
+
 import roster from './roster';
 import citadels from './citadels';
 import corporation from './corporation';
@@ -55,6 +57,8 @@ router.get('/character/:id/skillQueue', character_skillQueue);
 
 router.get('/dashboard', dashboard);
 router.get('/dashboard/queueSummary', dashboard_queueSummary);
+
+router.get('/statistics/skills', statistics_skills);
 
 router.get('/roster', roster);
 router.get('/citadels', citadels);

--- a/src/route/api/roster.ts
+++ b/src/route/api/roster.ts
@@ -48,7 +48,7 @@ export default jsonEndpoint((req, res, db, account, privs): Promise<Output> => {
   privs.requireRead('roster');
 
   return Promise.all([
-    dao.roster.getCharactersOwnedByMembers(db),
+    dao.roster.getCharactersOwnedByAssociatedAccounts(db),
     dao.roster.getUnownedCorpCharacters(db),
     getCorpNames(db),
   ])

--- a/src/route/api/statistics/skills.ts
+++ b/src/route/api/statistics/skills.ts
@@ -1,0 +1,82 @@
+import Promise = require('bluebird');
+
+import { jsonEndpoint } from '../../../route-helper/protectedEndpoint';
+import { dao } from '../../../dao';
+import { stringParam } from '../../../route-helper/paramVerifier';
+import { BadRequestError } from '../../../error/BadRequestError';
+
+import { SkillRequirement } from '../../../dao/StatisticsDao';
+
+const STATIC = require('../../../static-data').get();
+
+
+export interface Output {
+  query: string[],
+  stats: {
+    matchingAccounts: number,
+    totalAccounts: number,
+    percentage: string,
+  },
+  accounts: { main: string, killsOnMain: number }[];
+}
+
+export default jsonEndpoint((req, res, db, account, privs): Promise<Output> => {
+  // Format: <skillId>:<minLevel>,...
+  // eg. "3333:5,3335:5,3337:5"
+  let skillRequirements = parseQuery(req.query.q);
+
+  let numAccounts: number;
+
+  return Promise.resolve()
+  .then(() => {
+    return dao.roster.getMemberAccounts(db);
+  })
+  .then(rows => {
+    numAccounts = rows.length;
+
+    return dao.statistics.getTrainedPercentage(db, skillRequirements);
+  })
+  .then(rows => {
+    return {
+      query: skillRequirements.map(
+          sr => `${STATIC.SKILLS[sr.skill].name} ${sr.minLevel}`),
+      stats: {
+        matchingAccounts: rows.length,
+        totalAccounts: numAccounts,
+        percentage: Math.round(rows.length / numAccounts * 100) + '%',
+      },
+      accounts: rows.map((row: any) => {
+        return {
+          main: row.name,
+          killsOnMain: row.kills,
+        };
+      }),
+    };
+  });
+});
+
+const SKILL_PATTERN = /^(\d+):(\d+),?/;
+
+function parseQuery(query: string | undefined) {
+  if (query == undefined) {
+    throw new BadRequestError(`Mandatory query "q" missing.`);
+  }
+
+  let reqs = [] as SkillRequirement[];
+
+  let str = query;
+  while (str.length > 0) {
+    let match = SKILL_PATTERN.exec(str);
+    if (!match) {
+      throw new BadRequestError(
+          `Bad skills query: "${str}" in ${query}.`);
+    }
+    reqs.push({
+      skill: parseInt(match[1]),
+      minLevel: parseInt(match[2]),
+    });
+    str = str.substr(match[0].length);
+  }
+
+  return reqs;
+}

--- a/src/tnex/Tnex.ts
+++ b/src/tnex/Tnex.ts
@@ -27,6 +27,10 @@ export class Tnex {
     this._rootKnex = rootKnex;
   }
 
+  knex(): Knex {
+    return this._knex;
+  }
+
   transaction<T>(callback: (db: Tnex) => Promise<T>): Promise<T> {
     if (this._isTransaction()) {
       return callback(this); 


### PR DESCRIPTION
Pressing: needed due to T3 rebalance. No front-end yet :)

Computes how many accounts have at least one character that meets
a desired set of skill requirements.

Also adds a daily cron job to sync down all member skillsheets.

Skill requirements are specified via the "q" query param, e.g.
/api/statistics/skills?pretty&q=3335:5,3336:4

The q param should be of the form `<skill ID>:<min level>, ...`
For example: "3333:5,3335:5,3337:5"