### PR TITLE
Disable npm's package lock for now

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
sqlite3 is not currently compatible with the new package-lock
feature, so prevent npm from generating it until we move
completely to postgres.