### PR TITLE
Inject references to the DB connection

### DIFF
--- a/src/cron/Job.ts
+++ b/src/cron/Job.ts
@@ -1,8 +1,11 @@
+import { EventEmitter } from 'events';
 import Promise = require('bluebird');
 
-import { EventEmitter } from 'events';
+import { Tnex } from '../tnex';
 
-export type TaskExecutor = (job: JobTracker) => Promise<ExecutorResult>;
+
+export type TaskExecutor =
+    (db: Tnex, job: JobTracker) => Promise<ExecutorResult>;
 export type ExecutorResult = 'success' | 'partial';
 export type JobResult = 'pending' | ExecutorResult | 'failure';
 export type JobStatus = 'queued' | 'running' | 'finished';

--- a/src/cron/Scheduler.ts
+++ b/src/cron/Scheduler.ts
@@ -106,7 +106,7 @@ export class Scheduler {
         logger.info(`START ${jobSummary(job)}.`);
       }
 
-      const work = job.executor(job);
+      const work = job.executor(this._db, job);
       job.timeoutId = setTimeout(() => this._timeoutJob(job), job.timeout);
       job.setStatus('running', 'pending');
       return work;

--- a/src/cron/task/syncCharacterLocations.ts
+++ b/src/cron/task/syncCharacterLocations.ts
@@ -2,7 +2,6 @@ import Promise = require('bluebird');
 import moment = require('moment');
 
 import { getAccessTokenForCharacter } from '../../data-source/accessToken';
-import { db as rootDb } from '../../db';
 import { dao } from '../../dao';
 import { default as esi } from '../../esi';
 import { Tnex } from '../../tnex';
@@ -17,10 +16,10 @@ const RAPID_UPDATE_THRESHOLD = moment.duration(6, 'hours').asMilliseconds();
 
 
 export function syncCharacterLocations(
-    job: JobTracker): Promise<ExecutorResult> {
+    db: Tnex, job: JobTracker): Promise<ExecutorResult> {
   let completedCharacters = 0;
 
-  return dao.roster.getCharacterIdsOwnedByMemberAccounts(rootDb)
+  return dao.roster.getCharacterIdsOwnedByMemberAccounts(db)
   .then(characterIds => {
     job.setProgress(0, undefined);
 
@@ -29,7 +28,7 @@ export function syncCharacterLocations(
     let failedCharacterIds: number[] = []
 
     return Promise.map(characterIds, (characterId, i, len) => {
-      return maybeUpdateLocation(rootDb, characterId)
+      return maybeUpdateLocation(db, characterId)
       .catch(MissingTokenError, e => {
         noTokenCharacterIds.push(characterId);
       })

--- a/src/cron/task/syncKillboard.ts
+++ b/src/cron/task/syncKillboard.ts
@@ -2,7 +2,6 @@ import Promise = require('bluebird');
 import moment = require('moment');
 import axios from 'axios';
 
-import { db as rootDb } from '../../db';
 import { dao } from '../../dao';
 import { Tnex } from '../../tnex';
 import { serialize, doWhile } from '../../util/asyncUtil';
@@ -16,10 +15,11 @@ const PROGRESS_INTERVAL_PERC = 0.05;
 const ZKILL_MAX_RESULTS_PER_PAGE = 200;
 const MAX_FAILURES_BEFORE_BAILING = 10;
 
-export function syncKillboard(job: JobTracker): Promise<ExecutorResult> {
+export function syncKillboard(
+    db: Tnex, job: JobTracker): Promise<ExecutorResult> {
   return Promise.resolve()
   .then(getStartTime)
-  .then(startTime => fetchAll(rootDb, job, startTime))
+  .then(startTime => fetchAll(db, job, startTime))
   .then(([updateCount, failureCount]) => {
     logger.info(`Updated ${updateCount} characters' killboards.`);
     let result: ExecutorResult;

--- a/src/cron/task/syncRoster.ts
+++ b/src/cron/task/syncRoster.ts
@@ -14,14 +14,13 @@ import axios from 'axios';
 import moment = require('moment');
 import xml2js = require('xml2js');
 
-import { db as rootDb } from '../../db';
 import { Tnex, DEFAULT_NUM } from '../../tnex';
 import { dao } from '../../dao';
 import { MemberCorporation } from '../../dao/tables';
 import { serialize, parallelize } from '../../util/asyncUtil';
 import { UNKNOWN_CORPORATION_ID } from '../../util/constants';
 import { updateGroupsOnAllAccounts } from '../../data-source/accountGroups';
-import { ExecutorResult } from '../Job';
+import { JobTracker, ExecutorResult } from '../Job';
 
 import esi from '../../esi';
 
@@ -30,10 +29,10 @@ const logger = require('../../util/logger')(__filename);
 
 type Xml = any;
 
-export function syncRoster(): Promise<ExecutorResult> {
-  return updateAllCorporations(rootDb)
-  .then(processedIds => updateOrphanedOrUnknownCharacters(rootDb, processedIds))
-  .then(() => updateGroupsOnAllAccounts(rootDb))
+export function syncRoster(db: Tnex, job: JobTracker): Promise<ExecutorResult> {
+  return updateAllCorporations(db)
+  .then(processedIds => updateOrphanedOrUnknownCharacters(db, processedIds))
+  .then(() => updateGroupsOnAllAccounts(db))
   .then(function() {
     logger.info('syncRoster() complete');
     return <ExecutorResult>'success';

--- a/src/cron/task/syncSkills.ts
+++ b/src/cron/task/syncSkills.ts
@@ -1,6 +1,5 @@
 import Promise = require('bluebird');
 
-import { db as rootDb } from '../../db';
 import { dao } from '../../dao';
 import { Tnex } from '../../tnex';
 import { JobTracker, ExecutorResult } from '../Job';
@@ -11,16 +10,16 @@ import { isAnyEsiError } from '../../util/error';
 const logger = require('../../util/logger')(__filename);
 
 
-export function syncSkills(job: JobTracker): Promise<ExecutorResult> {
+export function syncSkills(db: Tnex, job: JobTracker): Promise<ExecutorResult> {
   
-  return dao.roster.getCharacterIdsOwnedByMemberAccounts(rootDb)
+  return dao.roster.getCharacterIdsOwnedByMemberAccounts(db)
   .then(characterIds => {
     job.setProgress(0, undefined);
 
     let successCount = 0;
 
     return Promise.each(characterIds, (characterId, i, len) => {
-      return updateSkills(rootDb, characterId)
+      return updateSkills(db, characterId)
       .then(() => {
         successCount++;
       })

--- a/src/cron/task/truncateCharacterLocations.ts
+++ b/src/cron/task/truncateCharacterLocations.ts
@@ -1,16 +1,16 @@
 import Promise = require('bluebird');
 import moment = require('moment');
 
-import { db as rootDb } from '../../db';
 import { Tnex } from '../../tnex';
 import { dao } from '../../dao';
-import { ExecutorResult } from '../Job';
+import { JobTracker, ExecutorResult } from '../Job';
 
 
-export function truncateCharacterLocations(): Promise<ExecutorResult> {
+export function truncateCharacterLocations(
+    db: Tnex, job: JobTracker): Promise<ExecutorResult> {
   let cutoff = moment().subtract(120, 'days').valueOf();
 
-  return dao.characterLocation.deleteOldLocations(rootDb, cutoff)
+  return dao.characterLocation.deleteOldLocations(db, cutoff)
   .then(() => {
     return <ExecutorResult>'success';
   });

--- a/src/cron/task/truncateCronLog.ts
+++ b/src/cron/task/truncateCronLog.ts
@@ -1,14 +1,14 @@
 import Promise = require('bluebird');
 import moment = require('moment');
 
-import { db as rootDb } from '../../db';
-import { Tnex, DEFAULT_NUM } from '../../tnex';
+import { Tnex } from '../../tnex';
 import { dao } from '../../dao';
-import { ExecutorResult } from '../Job';
+import { JobTracker, ExecutorResult } from '../Job';
 
 
-export function truncateCronLog(): Promise<ExecutorResult> {
-  return dao.cron.dropOldJobs(rootDb, 10000)
+export function truncateCronLog(
+    db: Tnex, job: JobTracker): Promise<ExecutorResult> {
+  return dao.cron.dropOldJobs(db, 10000)
   .then(() => {
     return <ExecutorResult>'success';
   });

--- a/src/cron/tasks.ts
+++ b/src/cron/tasks.ts
@@ -95,7 +95,7 @@ interface TaskInternal extends Task {
 
 let _scheduler: Scheduler;
 
-export function init(db: Tnex, scheduler: Scheduler) {
+export function init(scheduler: Scheduler) {
   _scheduler = scheduler;
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,0 @@
-import { tables } from './dao/tables';
-import { getPostgresKnex } from './db/getPostgresKnex';
-
-export const db = tables.build(getPostgresKnex());

--- a/src/db/getPostgresKnex.ts
+++ b/src/db/getPostgresKnex.ts
@@ -41,8 +41,13 @@ const CONFIG = {
   connection: getConnection(process.env),
 };
 
+let pgKnex: knex | null = null;
+
 export function getPostgresKnex() {
-  const pgKnex = knex(CONFIG);
-  (pgKnex as any).CLIENT = CLIENT;
+  if (pgKnex == null) {
+    pgKnex = knex(CONFIG);
+    (pgKnex as any).CLIENT = CLIENT;
+  }
+
   return pgKnex;
 }

--- a/src/route-helper/getAccountPrivs.ts
+++ b/src/route-helper/getAccountPrivs.ts
@@ -9,7 +9,7 @@
  */
 import Promise = require('bluebird');
 
-import { db } from '../db';
+import { Tnex } from '../tnex';
 import { dao } from '../dao';
 import { getPrivileges } from './privileges';
 
@@ -22,7 +22,7 @@ export interface AccountSummary {
   created: number,
 }
 
-export function getAccountPrivs(accountId: number | undefined) {
+export function getAccountPrivs(db: Tnex, accountId: number | undefined) {
   if (accountId == undefined) {
     throw new NotLoggedInError();
   }

--- a/src/route-helper/protectedEndpoint.ts
+++ b/src/route-helper/protectedEndpoint.ts
@@ -16,7 +16,6 @@ import { NotLoggedInError } from '../error/NotLoggedInError';
 import { UnauthorizedClientError } from '../error/UnauthorizedClientError';
 import { UserVisibleError } from '../error/UserVisibleError';
 
-import { db } from '../db';
 import { Tnex } from '../tnex';
 import { AccountPrivileges } from './privileges';
 import { getAccountPrivs, AccountSummary } from './getAccountPrivs';
@@ -61,10 +60,11 @@ export function htmlEndpoint(handler: HtmlEndpointHandler): ExpressHandler {
   return function (req, res) {
     return Promise.resolve()
     .then(() => {
-      return getAccountPrivs(req.session.accountId)
+      return getAccountPrivs(req.db, req.session.accountId)
     })
     .then(accountPrivs => {
-      return handler(req, res, db, accountPrivs.account, accountPrivs.privs);
+      return handler(
+          req, res, req.db, accountPrivs.account, accountPrivs.privs);
     })
     .then(payload => {
       res.render(payload.template, payload.data);
@@ -79,10 +79,11 @@ export function jsonEndpoint(handler: JsonEndpointHandler): ExpressHandler {
   return function(req, res) {
     return Promise.resolve()
     .then(() => {
-      return getAccountPrivs(req.session.accountId)
+      return getAccountPrivs(req.db, req.session.accountId)
     })
     .then(accountPrivs => {
-      return handler(req, res, db, accountPrivs.account, accountPrivs.privs);
+      return handler(
+          req, res, req.db, accountPrivs.account, accountPrivs.privs);
     })
     .then(payload => {
       let space = req.query.pretty != undefined ? 2 : undefined;

--- a/src/route/authenticate.ts
+++ b/src/route/authenticate.ts
@@ -5,7 +5,6 @@ import Promise = require('bluebird');
 import axios from 'axios';
 import express = require('express');
 
-import { db as rootDb } from '../db';
 import { dao } from '../dao';
 import { Tnex, Nullable } from '../tnex';
 import { isAnyEsiError } from '../util/error';
@@ -55,7 +54,7 @@ export default function(req: express.Request, res: express.Response) {
     logger.info(`  Character: ${characterData.name}`);
 
     charData = characterData;
-    return handleCharLogin(rootDb, accountId, charData, charTokens);
+    return handleCharLogin(req.db, accountId, charData, charTokens);
   })
   .then(accountId => {
     logger.info('  accountId =', accountId);

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,8 +3,9 @@ require('source-map-support').install();
 
 import Promise = require('bluebird');
 
-import { db } from './db';
 import { isDevelopment } from './util/config';
+import { tables } from './dao/tables';
+import { getPostgresKnex } from './db/getPostgresKnex';
 import { Scheduler } from './cron/Scheduler';
 
 import * as express from './express';
@@ -28,10 +29,11 @@ for (let envVar of REQUIRED_VARS) {
   }
 }
 
-let scheduler = new Scheduler(db);
+const db = tables.build(getPostgresKnex());
 
-tasks.init(db, scheduler);
+let scheduler = new Scheduler(db);
+tasks.init(scheduler);
 cron.init(db);
-express.init(port => {
+express.init(db, port => {
   logger.info(`Serving from port ${port}.`);
 });

--- a/src/types/expressTypes.ts
+++ b/src/types/expressTypes.ts
@@ -1,0 +1,9 @@
+import { Tnex } from '../tnex';
+
+declare global {
+  namespace Express {
+    interface Request {
+      db: Tnex,
+    }
+  }
+}


### PR DESCRIPTION
Instead of having every module include `src/db.ts`, pass it to
them explicitly:
- All route handlers can get a reference to the DB connection via
the express request object (we inject it there).
- All tasks get the DB connection passed to them directly as
parameter.