### PR TITLE
Access token fetch survives 400s from CCP

### DIFF
--- a/src/cron/task/syncCharacterLocations.ts
+++ b/src/cron/task/syncCharacterLocations.ts
@@ -6,7 +6,7 @@ import { dao } from '../../dao';
 import { default as esi } from '../../esi';
 import { Tnex } from '../../tnex';
 import { JobTracker } from '../Job';
-import { MissingTokenError } from '../../error/MissingTokenError';
+import { AccessTokenError } from '../../error/AccessTokenError';
 import { isAnyEsiError } from '../../util/error';
 
 const logger = require('../../util/logger')(__filename);
@@ -29,7 +29,7 @@ export function syncCharacterLocations(
 
     return Promise.map(characterIds, (characterId, i, len) => {
       return maybeUpdateLocation(db, characterId)
-      .catch(MissingTokenError, e => {
+      .catch(AccessTokenError, e => {
         noTokenCharacterIds.push(characterId);
       })
       .catch(isAnyEsiError, e => {

--- a/src/cron/task/syncSkills.ts
+++ b/src/cron/task/syncSkills.ts
@@ -4,7 +4,7 @@ import { dao } from '../../dao';
 import { Tnex } from '../../tnex';
 import { JobTracker } from '../Job';
 import { updateSkills } from '../../data-source/skills';
-import { MissingTokenError } from '../../error/MissingTokenError';
+import { AccessTokenError } from '../../error/AccessTokenError';
 import { isAnyEsiError } from '../../util/error';
 
 const logger = require('../../util/logger')(__filename);
@@ -23,7 +23,7 @@ export function syncSkills(db: Tnex, job: JobTracker): Promise<void> {
       .then(() => {
         successCount++;
       })
-      .catch(MissingTokenError, e => {
+      .catch(AccessTokenError, e => {
         logger.warn(`Missing access token for character ${characterId}, ` +
             `skipping...`);
       })

--- a/src/dao/AccessTokenDao.ts
+++ b/src/dao/AccessTokenDao.ts
@@ -28,9 +28,27 @@ export default class AccessTokenDao {
       characterId: number,
       row: TokenUpdate) {
     return db
-        .update(accessToken, row)
+        .update(accessToken, {
+          accessToken_accessToken: row.accessToken_accessToken,
+          accessToken_accessTokenExpires: row.accessToken_accessTokenExpires,
+          accessToken_needsUpdate: false,
+        })
         .where('accessToken_character', '=', val(characterId))
         .run();
+  }
+
+  markAsExpired(db: Tnex, characterId: number) {
+    return db
+        .update(accessToken, {
+          accessToken_needsUpdate: true
+        })
+        .where('accessToken_character', '=', val(characterId))
+        .run()
+    .then(updateCount => {
+      if (updateCount != 1) {
+        throw new Error(`No token to update for character ${characterId}.`);
+      }
+    })
   }
 
   upsert(

--- a/src/error/AccessTokenError.ts
+++ b/src/error/AccessTokenError.ts
@@ -1,0 +1,24 @@
+import { ExtendableError } from './ExtendableError';
+
+export const enum AccessTokenErrorType {
+  TOKEN_MISSING,
+  TOKEN_REFRESH_REJECTED,
+}
+
+export class AccessTokenError extends ExtendableError {
+  constructor(
+      public readonly characterId: number,
+      public readonly type: AccessTokenErrorType,
+      ) {
+    super(getMessage(type, characterId));
+  }
+}
+
+function getMessage(errorType: AccessTokenErrorType, characterId: number) {
+  switch (errorType) {
+    case AccessTokenErrorType.TOKEN_MISSING:
+      return `Missing access token for character ${characterId}`;
+    case AccessTokenErrorType.TOKEN_REFRESH_REJECTED:
+      return `Access token refresh rejected for character ${characterId}.`;
+  }
+}

--- a/src/error/MissingTokenError.ts
+++ b/src/error/MissingTokenError.ts
@@ -1,9 +1,0 @@
-import { ExtendableError } from './ExtendableError';
-
-export class MissingTokenError extends ExtendableError {
-  constructor(
-      public characterId: number
-      ) {
-    super(`Missing access token for character ${characterId}`);
-  }
-}


### PR DESCRIPTION
If a character's access token gets revoked, CCP will return 400
from a refresh request. We now detect this and set a flag on that
character instead of crashing the request.

It appears that sometimes access tokens we get invalidated even
without their owner invalidating the token.