### PR TITLE
Add visual prompt to reauth characters with invalid access tokens

### DIFF
--- a/src/client/dashboard/OwnedCharacterSlab.vue
+++ b/src/client/dashboard/OwnedCharacterSlab.vue
@@ -20,9 +20,7 @@
         </tooltip>
       </div>
       <div class="training-summary">
-        <div class="training-track"
-            :class="{ errorState: isInErrorState }"
-            >
+        <div class="training-track">
           <div class="training-progress"
               :style="{ width: progressTrackWidth }"
               ></div>
@@ -60,16 +58,13 @@
         tooltipGravity="left"
         />
   </div>
-  <div class="auth-bother-container"
-      slot="sub-slab-hanger"
+  <reauthentication-prompt
       v-if="character.needsReauth"
+      slot="sub-slab-hanger"
+      :loginParams="loginParams"
+      :characterName="character.name"
       >
-    <div class="auth-bother-title">Character needs to be re-authorized</div>
-    Please
-    <a :href="'https://login.eveonline.com/oauth/authorize?' + loginParams"
-        >log in</a>
-    as {{ character.name }}.
-  </div>
+  </reauthentication-prompt>
 </character-slab-frame>
 </template>
 
@@ -77,6 +72,7 @@
 import ajaxer from '../shared/ajaxer';
 
 import CharacterSlabFrame from './CharacterSlabFrame.vue';
+import ReauthenticationPrompt from './ReauthenticationPrompt.vue';
 import DropMenu from '../shared/DropMenu.vue';
 import LoadingSpinner from '../shared/LoadingSpinner.vue';
 import Tooltip from '../shared/Tooltip.vue';
@@ -91,6 +87,7 @@ import { CORP_DOOMHEIM } from '../../shared/eveConstants';
 export default {
   components: {
     CharacterSlabFrame,
+    ReauthenticationPrompt,
     DropMenu,
     LoadingSpinner,
     Tooltip,
@@ -123,14 +120,8 @@ export default {
       return this.character.skillQueue.queue;
     },
 
-    isInErrorState() {
-      return this.character.needsReauth;
-    },
-
     trainingLabel() {
-       if (this.character.needsReauth) {
-        return 'Needs authorization!';
-      } else if (this.character.skillQueue.queueStatus == 'empty') {
+      if (this.character.skillQueue.queueStatus == 'empty') {
         return 'Skill queue empty';
       } else if (this.character.skillQueue.queueStatus == 'paused') {
         return 'Skill queue paused';
@@ -354,10 +345,6 @@ function getQueueWarningLabel(warning) {
   background: #26221e;
 }
 
-.training-track.errorState {
-  background: url('../assets/Dashboard-barberpole-error.png');
-}
-
 .training-progress {
   position: absolute;
   left: 0;
@@ -379,17 +366,6 @@ function getQueueWarningLabel(warning) {
 
 .queue-summary, .training-remaining {
   font-size: 12px;
-  color: #a7a29c;
-}
-
-.auth-bother-container {
-  background: #3d3d3d;
-  padding: 12px;
-}
-
-.auth-bother-title {
-  font-size: 16px;
-  margin-bottom: 6px;
   color: #a7a29c;
 }
 

--- a/src/client/dashboard/ReauthenticationPrompt.vue
+++ b/src/client/dashboard/ReauthenticationPrompt.vue
@@ -1,0 +1,56 @@
+<template>
+<div class="_reauthentication-prompt"
+    >
+  <div class="cnt-left">
+    <div class="bother-title">Character needs to be reauthorized.</div>
+    Log in as "{{ characterName }}".
+  </div>
+  <div class="cnt-right">
+    <a class="reauth-btn roster-btn"
+        :href="'https://login.eveonline.com/oauth/authorize?' + loginParams"
+        >Reauthorize</a>
+  </div>
+</div>
+</template>
+
+<script>
+export default {
+  props: {
+    loginParams: { type: String, required: true },
+    characterName: { type: String, required: true },
+  }
+}
+</script>
+
+<style scoped>
+._reauthentication-prompt {
+  background: #c5751d;
+  padding: 12px;
+  display: flex;
+}
+
+.cnt-left {
+  flex: 1;
+  color: #212121;
+}
+
+.cnt-right {
+  margin-left: 20px;
+  align-self: center;
+}
+
+.bother-title {
+  font-size: 16px;
+  margin-bottom: 6px;
+  color: #000;
+}
+
+.reauth-btn {
+  display: inline-block;
+  text-decoration: none;
+  color: #cdcdcd;
+  padding: 7px 12px;
+  border-color: #462917;
+  border-radius: 2px;
+}
+</style>

--- a/src/client/dev/DevOwnedCharacterSlab.vue
+++ b/src/client/dev/DevOwnedCharacterSlab.vue
@@ -113,7 +113,7 @@
   <!-- Misc -->
   <div class="section">Misc</div>
 
-  <div class="entry-title">Needs reauth (needs rework)</div>
+  <div class="entry-title">Needs reauth</div>
   <owned-character-slab
       :accountId="0"
       :character="characterNeedsReauth"
@@ -140,7 +140,7 @@ export default {
       characterOpsecAlt: characterOpsec(),
       characterEsiFailure: characterBasic(warningSkillQueue()),
       characterBiomassed: characterBiomassed(),
-      characterNeedsReauth: characterNeedsReauth(),
+      characterNeedsReauth: characterNeedsReauth(warningSkillQueue()),
       characterEmptyQueue: characterBasic(emptySkillQueue()),
       characterPausedQueue: characterBasic(pausedSkillQueue()),
       characterUnfresQueue: characterBasic(unfreshSkillQueue()),

--- a/src/dao/CharacterDao.ts
+++ b/src/dao/CharacterDao.ts
@@ -61,6 +61,7 @@ export default class CharacterDao {
             'ownership_opsec',
             'memberCorporation_membership',
             'account_mainCharacter',
+            'accessToken_needsUpdate',
             )
         .run();
   }

--- a/src/route/api/dashboard.ts
+++ b/src/route/api/dashboard.ts
@@ -28,6 +28,7 @@ interface CharacterJson {
   corpStatus: string,
   skillQueue: SkillQueueSummary,
   corpId: number,
+  needsReauth: boolean,
 }
 
 export default jsonEndpoint((req, res, db, account, privs): Promise<Output> => {
@@ -62,6 +63,7 @@ export default jsonEndpoint((req, res, db, account, privs): Promise<Output> => {
           corpStatus: getCorpStatus(row.memberCorporation_membership),
           skillQueue: queue,
           corpId: row.character_corporationId,
+          needsReauth: row.accessToken_needsUpdate !== false,
         };
       });
     });


### PR DESCRIPTION
Removes some vestigial UI for this that was never triggered and replaces it with a very loud reauth window underneath the character slab.