### PR TITLE
Fix minor type changes in latest Typescript release

### DIFF
--- a/src/route/api/admin/citadel_PUT.ts
+++ b/src/route/api/admin/citadel_PUT.ts
@@ -25,8 +25,5 @@ export default jsonEndpoint((req, res, db, account, privs) => {
     if (updateCount == 0) {
       throw new BadRequestError(`No such citadel w/ id "${citadelId}`);
     }
-  })
-  .catch(SchemaVerificationError, e => {
-    throw new BadRequestError(e.message);
   });
 });

--- a/src/tnex/Tnex.ts
+++ b/src/tnex/Tnex.ts
@@ -67,19 +67,21 @@ export class Tnex {
     return new ValueWrapper(value);
   }
 
-  public insert<T extends object>(table: T, row: T): Promise<void>;
-  public insert<T extends object, K extends keyof T>(
-      table: T, row: T, returning: K): Promise<T[K]>;
-  public insert<T extends object, K extends keyof T, L extends keyof T>(
-      table: T, row: T, returning: [K, L]): Promise<[T[K], T[L]]>;
+  public insert<T extends object, R extends T = T>(table: T, row: R): Promise<void>;
+  public insert<T extends object, K extends keyof T, R extends T = T>(
+      table: T, row: R, returning: K): Promise<T[K]>;
+  public insert
+      <T extends object, K extends keyof T, L extends keyof T, R extends T = T>
+      (table: T, row: R, returning: [K, L]): Promise<[T[K], T[L]]>;
   public insert<
       T extends object,
       K extends keyof T,
       L extends keyof T,
-      M extends keyof T>
-      (table: T, row: T, returning: [K, L, M]): Promise<[T[K], T[L], T[M]]>;
-  public insert<T extends object>(
-      table: T, row: T, returning?: string|string[]) {
+      M extends keyof T,
+      R extends T = T>
+      (table: T, row: R, returning: [K, L, M]): Promise<[T[K], T[L], T[M]]>;
+  public insert<T extends object, R extends T = T>(
+      table: T, row: R, returning?: string|string[]) {
     let tableName = this._registry.getTableName(table);
     return this._knex(tableName)
         .insert(


### PR DESCRIPTION
- Type inference was widening the "table" (T) type if you supplied an
incomplete row type. This allowed you to pass rows that were missing
fields defined in the table. Fixed this with a new row type (R) that
defaults to T.
- Bluebird's type-aware catch blocks seem to be busted right now, but
the one place where this was a problem wasn't necessary (this same
behavior is caught in jsonEndpoint) so I just deleted it.