### PR TITLE
Tnex tweaks and fixes

### DIFF
--- a/src/tnex/Joiner.ts
+++ b/src/tnex/Joiner.ts
@@ -105,13 +105,7 @@ export class Joiner<J extends object /* joined */, S /* selected */>
    */
 
   
-  // Normal join
-  public join<T extends object>(
-      table: T,
-      left: keyof T,
-      cmp: Comparison,
-      right: keyof J,
-  ): Joiner<J & T, S>;
+
   // Subjoin
   public join<T extends object, E>(
       subselect: Joiner<T, E>,
@@ -126,6 +120,13 @@ export class Joiner<J extends object /* joined */, S /* selected */>
       cmp: Comparison,
       right: keyof J,
       ): Joiner<J & E, S>;
+  // Normal join
+  public join<T extends object>(
+      table: T,
+      left: keyof T,
+      cmp: Comparison,
+      right: keyof J,
+  ): Joiner<J & T, S>;
   // Implementation
   public join(
       table: object,
@@ -142,6 +143,7 @@ export class Joiner<J extends object /* joined */, S /* selected */>
       this._scoper.registerSyntheticPrefix(requiredPrefix);
     } else if (table instanceof RenamedJoin) {
       joinTarget = this._processRenamedJoin(table);
+      this._scoper.registerSyntheticPrefix(table.tableAlias);
     } else {
       joinTarget = this._processJoin(table);
     }
@@ -155,13 +157,7 @@ export class Joiner<J extends object /* joined */, S /* selected */>
     return this;
   }
 
-  // Normal
-  public leftJoin<T extends object>(
-      table: T,
-      left: keyof T,
-      cmp: Comparison,
-      right: keyof J,
-      ): Joiner<J & Nullable<T>, S>;
+
   // Subselect
   public leftJoin<T extends object, E>(
       sub: Joiner<T, E>,
@@ -176,6 +172,13 @@ export class Joiner<J extends object /* joined */, S /* selected */>
       cmp: Comparison,
       right: keyof J,
       ): Joiner<J & Nullable<E>, S>;
+  // Normal
+  public leftJoin<T extends object>(
+      table: T,
+      left: keyof T,
+      cmp: Comparison,
+      right: keyof J,
+      ): Joiner<J & Nullable<T>, S>;
   // Implementation
   public leftJoin(
       table: object,
@@ -192,8 +195,8 @@ export class Joiner<J extends object /* joined */, S /* selected */>
       requiredPrefix = assertHasValue(table._subqueryTableName);
       this._scoper.registerSyntheticPrefix(requiredPrefix);
     } else if (table instanceof RenamedJoin) {
-      this._scoper.registerSyntheticPrefix(table.tableAlias);
       joinTarget = this._processRenamedJoin(table);
+      this._scoper.registerSyntheticPrefix(table.tableAlias);
     } else {
       joinTarget = this._processJoin(table);
     }

--- a/src/tnex/core.ts
+++ b/src/tnex/core.ts
@@ -2,6 +2,17 @@ export type ColumnType = number | string | boolean | Date;
 
 export type Comparison = '=' | '!=' | '<' | '>' | '<=' | '>=';
 
+export enum ResultOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+/**
+ * Extracts and renames a property of T.
+ * 
+ * Given a type T and a key of T, K, creates a new type with a single
+ * property named L that has type T[K].
+ */
 export type Link<T, K extends keyof T, L extends string> = {
   [P in L]: T[K]
 };

--- a/src/tnex/definers.ts
+++ b/src/tnex/definers.ts
@@ -22,3 +22,7 @@ export function boolinum(): number {
 export function enu<K extends string>(): K {
   return '' as K;
 }
+
+export function json<K extends object>(): K {
+  return {} as K;
+}

--- a/src/tnex/index.ts
+++ b/src/tnex/index.ts
@@ -4,10 +4,10 @@ import { Tnex } from './Tnex';
 
 export { TnexBuilder } from './TnexBuilder';
 
-export { val } from './core';
+export { val, ResultOrder, } from './core';
 export { Tnex } from './Tnex';
 export { Nullable } from './Joiner';
-export { nullable, number, string, boolean, boolinum, enu } from './definers';
+export { nullable, number, string, boolean, boolinum, enu, json } from './definers';
 
 export {
   DEFAULT_NUM,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     /* Basic Options */                       
     "target": "es2017",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es2015'. */
-    "lib": ["es6", "es2016.array.include", "dom"],                             /* Specify library files to be included in the compilation:  */
+    "lib": ["es2017", "dom"],                             /* Specify library files to be included in the compilation:  */
     "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
- Switch to calling Bluebird its own name instead of Promise
- Stop checking to make sure run() was called -- this is much
harder to accidentally do with typed returns.
- Fix some bugs in the generics for where/orWhere/andWhere
- Properly order overrides of join/leftJoin
- Add a new `json()` function for table column definitions.