### PR TITLE
Add SRP tracking backend

### DIFF
--- a/schema/006-srp.js
+++ b/schema/006-srp.js
@@ -1,0 +1,62 @@
+
+/**
+ * Adds tables related to tracking SRP.
+ */
+exports.up = async function(trx) {
+  await trx.schema.createTable('srpReimbursement', table => {
+    table.increments('id');
+
+    table.integer('recipientCharacter').notNullable();
+    table.bigInteger('modified').notNullable();
+    table.boolean('paid').notNullable();
+    table.integer('payingCharacter').references('character.id').nullable();
+  });
+
+  await trx.schema.createTable('srpVerdict', table => {
+    table.integer('killmail').primary().references('killmail.id').notNullable();
+    table.string('status').notNullable();
+    table.string('reason').nullable();
+    table.integer('payout').notNullable();
+    table.integer('reimbursement').references('srpReimbursement.id').nullable();
+    table.bigInteger('modified').notNullable();
+    table.integer('renderingAccount').references('account.id').nullable();
+  });
+
+  await trx('privilege')
+      .insert([
+        {
+          name: 'srp',
+          category: 'operations',
+          ownerLevel: 0,
+          requiresMembership: true,
+          description: 'Read and write to the SRP log.',
+        },
+      ]);
+
+  await trx('groupPriv')
+      .insert([
+        { group: '__member', privilege: 'srp', level: 1 },
+        { group: 'admin', privilege: 'srp', level: 2 },
+      ]);
+
+  await trx('privilege')
+      .update({ category: 'operations' })
+      .where('name', '=', 'citadels' );
+}
+
+exports.down = async function(trx) {
+  await trx('privilege')
+      .update({ category: 'admin' })
+      .where('name', '=', 'citadels');
+
+  await trx('groupPriv')
+      .del()
+      .where('privilege', '=', 'srp');
+
+  await trx('privilege')
+      .del()
+      .where('name', '=', 'srp');
+
+  await trx.schema.dropTable('srpVerdict');
+  await trx.schema.dropTable('srpReimbursement');
+}

--- a/src/dao.ts
+++ b/src/dao.ts
@@ -11,6 +11,7 @@ import KillmailDao from './dao/KillmailDao';
 import LogDao from './dao/LogDao';
 import OwnershipDao from './dao/OwnershipDao';
 import RosterDao from './dao/RosterDao';
+import SrpDao from './dao/SrpDao';
 import SkillsheetDao from './dao/SkillsheetDao';
 import SkillQueueDao from './dao/SkillQueueDao';
 import StatisticsDao from './dao/StatisticsDao';
@@ -34,6 +35,7 @@ export class Dao {
   public log = new LogDao(this);
   public ownership = new OwnershipDao(this);
   public roster = new RosterDao(this);
+  public srp = new SrpDao(this);
   public skillQueue = new SkillQueueDao(this);
   public skillsheet = new SkillsheetDao(this);
   public statistics = new StatisticsDao(this);

--- a/src/dao/SrpDao.ts
+++ b/src/dao/SrpDao.ts
@@ -1,0 +1,318 @@
+import { Dao } from '../dao';
+import { Tnex, DEFAULT_NUM } from '../tnex';
+import { killmail, Killmail, character, srpReimbursement, srpVerdict, ownership, SrpReimbursement, SrpVerdict, account, Account } from './tables';
+import { SrpVerdictStatus, SrpVerdictReason } from './enums';
+import { val, Comparison } from '../tnex/core';
+import { Nullable } from '../util/simpleTypes';
+import { ZKillmail } from '../data-source/zkillboard/ZKillmail';
+
+
+export interface SrpLossFilter {
+  status?: SrpVerdictStatus,
+  limit?: number,
+  order?: 'asc' | 'desc',
+  fromKillmail?: number,
+  account?: number,
+  character?: number,
+  killmail?: number,
+  reimbursement?: number,
+}
+
+export interface SrpReimbursementFilter {
+  paid: boolean | undefined,
+  account: number | undefined,
+  limit: number | undefined,
+  order: 'asc' | 'desc',
+  orderBy: 'id' | 'modified',
+  startingAfter: number | undefined,
+}
+
+export default class SrpDao {
+  constructor(
+      private _dao: Dao,
+      ) {
+  }
+
+  async addSrpVerdictEntries(db: Tnex, rows: SrpVerdict[]) {
+    await db.insertAll(srpVerdict, rows);
+  }
+
+  async listUntriagedLosses(db: Tnex) {
+    return db
+        .select(killmail)
+        .leftJoin(srpVerdict, 'srpv_killmail', '=', 'km_id')
+        .leftJoin(
+            db.alias(killmail, 'related')
+                .using('km_id', 'related_id')
+                .using('km_data', 'related_data'),
+            'related_id', '=', 'km_relatedLoss')
+        .leftJoin(ownership, 'ownership_character', '=', 'km_character')
+        .leftJoin(account, 'account_id', '=', 'ownership_account')
+        .whereNull('srpv_killmail')
+        .orderBy('km_id', 'asc')
+        .columns(
+            'km_data',
+            'related_data',
+            'account_mainCharacter',
+            )
+        .run();
+  }
+
+  async listSrps(db: Tnex, filter: SrpLossFilter): Promise<SrpLossRow[]> {
+    let order = filter.order || 'desc';
+
+    let query = db
+        .select(killmail)
+        .join(srpVerdict, 'srpv_killmail', '=' ,'km_id')
+        .leftJoin(srpReimbursement, 'srpr_id', '=', 'srpv_reimbursement')
+        .leftJoin(ownership, 'ownership_character', '=', 'km_character')
+        .leftJoin(account, 'account_id', '=', 'ownership_account')
+        .leftJoin(
+            db.alias(killmail, 'related')
+                .using('km_id', 'related_id')
+                .using('km_data', 'related_data'),
+            'related_id', '=', 'km_relatedLoss')
+        .orderBy('km_id', order)
+        .columns(
+            'km_id',
+            'km_timestamp',
+            'km_data',
+            'km_relatedLoss',
+            'srpv_status',
+            'srpv_reason',
+            'srpv_payout',
+            'srpr_id',
+            'srpr_paid',
+            'srpr_payingCharacter',
+            'related_data',
+            'account_mainCharacter',
+            );
+    if (filter.limit != undefined) {
+      query = query.limit(filter.limit);
+    }
+    if (filter.status == 'pending') {
+      query = query.where('srpv_status', '=', val(SrpVerdictStatus.PENDING))
+    }
+    if (filter.fromKillmail != undefined) {
+      let cmp: Comparison = order == 'desc' ? '<' : '>';
+      query = query.where('km_id', cmp, val(filter.fromKillmail));
+    }
+    if (filter.character != undefined) {
+      query = query.where('km_character', '=', val(filter.character));
+    } else if (filter.account != undefined) {
+      query = query.where('account_id', '=', val(filter.account));
+    }
+    if (filter.killmail != undefined) {
+      query = query.where('km_id', '=', val(filter.killmail));
+    }
+    if (filter.reimbursement != undefined) {
+      query = query.where('srpv_reimbursement', '=', val(filter.reimbursement));
+    }
+
+    return query.run();
+  }
+
+  async setSrpVerdict(
+      db: Tnex,
+      killmailId: number,
+      verdict: SrpVerdictStatus,
+      reason: SrpVerdictReason | null,
+      payout: number,
+      renderingAccount: number | null,
+  ) {
+    // If SRP already associated with a paid reimbursement, ERROR
+    // If verdict is ACCEPTED, create a reimbursement if necessary
+    // Otherwise, just null out reimbursement
+
+    return db.asyncTransaction(async db => {
+      await db.acquireTransactionalLock(srpReimbursement, -1);
+
+      const row = await db
+          .select(srpVerdict)
+          .join(killmail, 'km_id', '=', 'srpv_killmail')
+          .leftJoin(ownership, 'ownership_character', '=', 'km_character')
+          .leftJoin(account, 'account_id', '=', 'ownership_account')
+
+          // Any preexisting reimbursement associated with this *loss*
+          .leftJoin(srpReimbursement,
+              'srpr_recipientCharacter', '=', 'account_mainCharacter')
+
+          // Any preexisting reimbursement associated with this *account*
+          .leftJoin(
+              db.alias(srpReimbursement, 'acctReim')
+                  .using('srpr_id', 'acctReim_id')
+                  .using(
+                      'srpr_recipientCharacter',
+                      'acctReim_recipientCharacter'),
+              'acctReim_recipientCharacter', '=', 'account_mainCharacter')
+
+          // Any preexisting reimbursement associated with this *character*
+          // (used if above is null)
+          .leftJoin(
+              db.alias(srpReimbursement, 'victimReim')
+                  .using('srpr_id', 'victimReim_id')
+                  .using(
+                      'srpr_recipientCharacter',
+                      'victimReim_recipientCharacter'),
+              'victimReim_recipientCharacter', '=', 'km_character')
+
+          .where('srpv_killmail', '=', val(killmailId))
+          .columns(
+              'km_character',
+              'srpv_status',
+              'srpr_paid',
+              'acctReim_id',
+              'victimReim_id',
+              )
+          .fetchFirst();
+      if (row == null) {
+        return 0;
+      }
+      if (row.srpr_paid) {
+        throw new Error(`Cannot change the verdict on a paid SRP.`);
+      }
+
+      let reimbursement: null | number = null;
+
+      // Create a reimbursement if necessary
+      if (verdict == SrpVerdictStatus.APPROVED) {
+        reimbursement = row.acctReim_id || row.victimReim_id;
+        if (reimbursement == null) {
+          reimbursement = await this.createReimbursement(db, row.km_character);
+        }
+      }
+
+      return await db
+          .update(srpVerdict, {
+            srpv_status: verdict,
+            srpv_reason: reason,
+            srpv_payout: payout,
+            srpv_reimbursement: reimbursement,
+            srpv_renderingAccount: renderingAccount,
+            srpv_modified: Date.now(),
+          })
+          .where('srpv_killmail', '=', val(killmailId))
+          .run();
+    });
+  }
+
+  async listReimbursements(
+      db: Tnex,
+      filter: SrpReimbursementFilter,
+  ) {
+    // Subquery: for each reimbursement, the sum of its approved payouts
+    let subquery = db
+        .subselect(srpReimbursement, 'combined')
+        .join(srpVerdict, 'srpv_reimbursement', '=', 'srpr_id')
+        .sum('srpv_payout', 'combined_payout')
+        .count('srpv_killmail', 'combined_losses')
+        .columnAs('srpr_id', 'combined_id')
+        .groupBy('srpr_id')
+        .orderBy('srpr_modified', filter.order);
+
+    if (filter.paid != undefined) {
+      subquery = subquery.where('srpr_paid', '=', val(filter.paid));
+    }
+    if (filter.account != undefined) {
+      subquery = subquery
+          .join(ownership,
+              'ownership_character', '=', 'srpr_recipientCharacter')
+          .where('ownership_account', '=', val(filter.account));
+    }
+    if (filter.limit != undefined) {
+      subquery = subquery.limit(filter.limit);
+    }
+    if (filter.startingAfter != undefined) {
+      subquery = subquery.andWhere(
+          filter.orderBy == 'id' ? 'srpr_id' : 'srpr_modified', 
+          filter.order == 'desc' ? '<' : '>',
+          val(filter.startingAfter));
+    }
+
+    return await db
+        .select(srpReimbursement)
+        .join(subquery, 'combined_id', '=', 'srpr_id')
+        .leftJoin(character, 'character_id', '=', 'srpr_recipientCharacter')
+        .leftJoin(
+            db.alias(character, 'payingChar')
+                .using('character_id', 'payingChar_id')
+                .using('character_corporationId', 'payingChar_corporationId'),
+            'payingChar_id', '=', 'srpr_payingCharacter')
+        .where('combined_losses', '>', val(0))
+        .columns(
+            'srpr_id',
+            'srpr_modified',
+            'combined_payout',
+            'combined_losses',
+            'srpr_recipientCharacter',
+            'character_corporationId',
+            'srpr_payingCharacter',
+            'payingChar_corporationId',
+            )
+        .run();
+  }
+
+  async getReimbursement(db: Tnex, id: number) {
+    return db
+      .select(srpReimbursement)
+      .where('srpr_id', '=', val(id))
+      .columns(
+          'srpr_recipientCharacter',
+          'srpr_modified',
+          'srpr_paid',
+          'srpr_payingCharacter',
+          )
+      .fetchFirst();
+  }
+
+  async markReimbursementAsPaid(
+      db: Tnex, reimbursement: number, payingCharacter: number) {
+    return await db
+        .update(srpReimbursement, {
+          srpr_paid: true,
+          srpr_modified: Date.now(),
+          srpr_payingCharacter: payingCharacter,
+        })
+        .where('srpr_id', '=', val(reimbursement))
+        .run();
+  }
+
+  async markReimbursementAsUnpaid(db: Tnex, reimbursement: number) {
+    return await db
+        .update(srpReimbursement, {
+          srpr_paid: false,
+          srpr_modified: Date.now(),
+          srpr_payingCharacter: null,
+        })
+        .where('srpr_id', '=', val(reimbursement))
+        .run();
+  }
+
+  private async createReimbursement(db: Tnex, character: number) {
+    return db
+        .insert(srpReimbursement, {
+          srpr_id: DEFAULT_NUM,
+          srpr_recipientCharacter: character,
+          srpr_modified: Date.now(),
+          srpr_paid: false,
+          srpr_payingCharacter: null,
+        }, 'srpr_id');
+  }
+}
+
+export type SrpLossRow =
+    Pick<
+        Killmail & SrpVerdict & Nullable<SrpReimbursement> & Nullable<Account>,
+        | 'km_id'
+        | 'km_timestamp'
+        | 'km_relatedLoss'
+        | 'km_data'
+        | 'srpv_status'
+        | 'srpv_reason'
+        | 'srpv_payout'
+        | 'srpr_id'
+        | 'srpr_paid'
+        | 'srpr_payingCharacter'
+        | 'account_mainCharacter'
+        >
+    & { related_data: ZKillmail | null };

--- a/src/dao/enums.ts
+++ b/src/dao/enums.ts
@@ -28,3 +28,30 @@ export enum HullCategory {
   CAPSULE = 'capsule',
   SHIP = 'ship',
 }
+
+export enum SrpVerdictStatus {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  INELIGIBLE = 'ineligible',
+}
+
+export enum SrpVerdictReason {
+  /** This ship is never covered by SRP */
+  NOT_COVERED = 'not_covered',
+  /** Hull is covered, but fit is not doctrine/missing modules/etc. */
+  INVALID_FIT = 'invalid_fit',
+  /** Loss didn't take place during a fleet fight, e.g. during PvE. */
+  INVALID_ENGAGEMENT = 'invalid_engagement',
+  /** Died to NPCs */
+  NPC = 'npc',
+  /** Specialized version of INVALID_ENGAGEMENT: solo combat. */
+  SOLO = 'solo',
+  /** Pilot has opted out of receiving SRP. */
+  OPT_OUT = 'opt_out',
+  /** Character is no longer a member. */
+  NO_LONGER_A_MEMBER = 'no_longer_a_member',
+  /** Loss is obsolete, perhaps due to being paid via some other channel. */
+  OBSOLETE = 'obsolete',
+  /** Uncategorized reason for ignoring a loss. */
+  MISC = 'misc',
+}

--- a/src/dao/tables.ts
+++ b/src/dao/tables.ts
@@ -1,5 +1,5 @@
 import { TnexBuilder, nullable, number, string, boolean, enu, json } from '../tnex';
-import { PrivilegeName, KillmailType, HullCategory } from './enums';
+import { PrivilegeName, KillmailType, HullCategory, SrpVerdictStatus, SrpVerdictReason } from './enums';
 import { ZKillmail } from '../data-source/zkillboard/ZKillmail';
 
 
@@ -254,3 +254,38 @@ export class SdeTypeAttribute {
   sta_valueFloat = nullable(number());
 }
 export const sdeTypeAttribute = tables.register(new SdeTypeAttribute());
+
+/**
+ * An SRP payment for a particular member. A single payment can include
+ * multiple losses across multiple characters (if all owned by the same
+ * account).
+ */
+export class SrpReimbursement {
+  srpr_id = number();
+  srpr_recipientCharacter = number();
+  srpr_modified = number();
+  srpr_paid = boolean();
+  srpr_payingCharacter = nullable(number());
+}
+export const srpReimbursement = tables.register(new SrpReimbursement());
+
+/**
+ * Whether a loss is eligible for SRP. If so, how much to pay. If not, why.
+ */
+export class SrpVerdict {
+  srpv_killmail = number();
+  srpv_status = enu<SrpVerdictStatus>();
+  /** Non-null iff status is Ineligible */
+  srpv_reason = nullable(enu<SrpVerdictReason>());
+  /** ISK */
+  srpv_payout = number();
+  /** Non-null iff status is Approved */
+  srpv_reimbursement = nullable(number());
+  srpv_modified = number();
+  /**
+   * The account that decided the verdict. Can be null even if a verdict has
+   * been rendered if the verdict was decided by a bot.
+   */
+  srpv_renderingAccount = nullable(number());
+}
+export const srpVerdict = tables.register(new SrpVerdict());

--- a/src/eve/names.ts
+++ b/src/eve/names.ts
@@ -1,0 +1,40 @@
+import swagger from '../swagger';
+import { SimpleNumMap, nil } from "../util/simpleTypes";
+
+
+const NAME_CACHE = new Map<number, string>();
+
+/**
+ * Fetches the names of a set of EVE entities (items, characters, alliances,
+ * etc.). These names are cached indefinitely; subsequent queries will be
+ * returned from the cache.
+ */
+export async function fetchEveNames(ids: Set<number | nil>) {
+  ids.delete(null);
+  ids.delete(undefined);
+
+  const idMap: SimpleNumMap<string> = {};
+  let unresolvedIds: number[] = [];
+  for (let id of ids) {
+    let name = NAME_CACHE.get(id!);
+    if (name == undefined) {
+      unresolvedIds.push(id!);
+    } else {
+      idMap[id!] = name;
+    }
+  }
+
+  let i = 0;
+  while (i < unresolvedIds.length) {
+    let end = Math.min(unresolvedIds.length, i + 1000);
+    const entries = await swagger.names(unresolvedIds.slice(i, end));
+    i = end;
+
+    for (let entry of entries) {
+      NAME_CACHE.set(entry.id, entry.name);
+      idMap[entry.id] = entry.name;
+    }
+  }
+
+  return idMap;
+}

--- a/src/route-helper/paramVerifier.ts
+++ b/src/route-helper/paramVerifier.ts
@@ -18,6 +18,38 @@ export function idParam(req: express.Request, key: string): number {
   return parseInt(strParam);
 }
 
+export function boolQuery(
+    req: express.Request, key: string): boolean | undefined {
+  if (req.query[key] == undefined) {
+    return undefined;
+  } else {
+    return req.query[key] == 'true' || req.query[key] == '';
+  }
+}
+
+export function intQuery(
+    req: express.Request, key: string): number | undefined {
+  if (isNaN(req.query[key])) {
+    return undefined;
+  } else {
+    return parseInt(req.query[key]);
+  }
+}
+
+export function enumQuery<EType extends string, Eobj extends object = object>(
+    req: express.Request, key: string, enu: Eobj): EType | undefined {
+  let value = req.query[key];
+  if (value === undefined) {
+    return value;
+  }
+  for (let v in enu) {
+    if (enu[v] == value) {
+      return value;
+    }
+  }
+  throw new BadRequestError(`Non-enum value "${value}" for key "${key}".`);
+}
+
 function getParam(req: express.Request, key: string): string {
   let param = req.params[key];
 

--- a/src/route/api/account/characters_GET.ts
+++ b/src/route/api/account/characters_GET.ts
@@ -1,0 +1,68 @@
+import Bluebird = require('bluebird');
+import { jsonEndpoint } from '../../../route-helper/protectedEndpoint';
+import { Tnex } from '../../../tnex/index';
+import { AccountSummary } from '../../../route-helper/getAccountPrivs';
+import { AccountPrivileges } from '../../../route-helper/privileges';
+import { idParam } from '../../../route-helper/paramVerifier';
+import { UnauthorizedClientError } from '../../../error/UnauthorizedClientError';
+import { dao } from '../../../dao';
+
+
+export type Output = CharacterDescription[];
+
+export interface CharacterDescription {
+  id: number,
+  name: string,
+  corporation: number,
+  membership: string | null,
+  accessTokenValid: boolean,
+  isMain: boolean,
+}
+
+
+/**
+ * Returns a list of all characters owned by a particular account. Currently,
+ * accounts can only ask about their own characters.
+ */
+export default jsonEndpoint(
+    (req, res, db, account, privs): Bluebird<Output> => {
+  const targetAccountId = idParam(req, 'id');
+
+  return Bluebird.resolve(handleEndpoint(db, account, privs, targetAccountId));
+});
+
+async function handleEndpoint(
+    db: Tnex,
+    account: AccountSummary,
+    privs: AccountPrivileges,
+    targetAccount: number,
+) {
+  // TODO: Allow other accounts to read if they have the right privs
+  if (targetAccount != account.id) {
+    throw new UnauthorizedClientError(
+        `Account ${account.id} cannot read characters of account`
+        + `${targetAccount}.`);
+  }
+
+  const rows =
+      await dao.character.getCharactersOwnedByAccount(db, targetAccount);
+
+  let chars: CharacterDescription[] = [];
+  for (let row of rows) {
+    let char = {
+      id: row.character_id,
+      name: row.character_name,
+      corporation: row.character_corporationId,
+      membership: row.memberCorporation_membership,
+      accessTokenValid: !row.accessToken_needsUpdate,
+      isMain: row.character_id == row.account_mainCharacter,
+    };
+    if (char.isMain) {
+      chars.unshift(char);
+    } else {
+      chars.push(char);
+    }
+  }
+
+  return chars;
+}

--- a/src/route/api/api.ts
+++ b/src/route/api/api.ts
@@ -1,6 +1,7 @@
 import express = require('express');
 
 import account_activeTimezone_PUT from './account/activeTimezone_PUT';
+import account_characters_GET from './account/characters_GET';
 import account_homeCitadel_PUT from './account/homeCitadel_PUT';
 import account_mainCharacter_PUT from './account/mainCharacter_PUT';
 import account_transfer_DELETE from './account/transfer_DELETE';
@@ -22,8 +23,18 @@ import character_character_PUT from './character/character_PUT';
 import character_character_DELETE from './character/character_DELETE';
 import character_skills from './character/skills';
 
+import control_openwindow_information_POST from './control/openwindow/information_POST';
+
 import dashboard from './dashboard';
 import dashboard_queueSummary from './dashboard/queueSummary';
+
+import killmail_GET from './killmail/killmail_GET';
+
+import srp_loss_dir_GET from './srp/loss/loss_dir_GET';
+import srp_loss_PUT from './srp/loss/loss_PUT';
+import srp_payment_dir_GET from './srp/payment/payment_dir_GET';
+import srp_payment_GET from './srp/payment/payment_GET';
+import srp_payment_PUT from './srp/payment/payment_PUT';
 
 import statistics_skills from './statistics/skills';
 
@@ -34,6 +45,7 @@ import corporation from './corporation';
 const router = express.Router();
 
 router.put('/account/:id/activeTimezone', account_activeTimezone_PUT);
+router.get('/account/:id/characters', account_characters_GET);
 router.put('/account/:id/homeCitadel', account_homeCitadel_PUT);
 router.put('/account/:id/mainCharacter', account_mainCharacter_PUT);
 router.post('/account/:id/transfer', account_transfer_POST);
@@ -55,8 +67,20 @@ router.put('/character/:id', character_character_PUT);
 router.delete('/character/:id', character_character_DELETE);
 router.get('/character/:id/skills', character_skills);
 
+router.post(
+    '/control/openwindow/information',
+    control_openwindow_information_POST);
+
 router.get('/dashboard', dashboard);
 router.get('/dashboard/queueSummary', dashboard_queueSummary);
+
+router.get('/killmail/:id', killmail_GET);
+
+router.get('/srp/loss', srp_loss_dir_GET);
+router.put('/srp/loss/:id', srp_loss_PUT);
+router.get('/srp/payment', srp_payment_dir_GET);
+router.get('/srp/payment/:id', srp_payment_GET);
+router.put('/srp/payment/:id', srp_payment_PUT);
 
 router.get('/statistics/skills', statistics_skills);
 

--- a/src/route/api/control/openwindow/information_POST.ts
+++ b/src/route/api/control/openwindow/information_POST.ts
@@ -1,0 +1,52 @@
+import Bluebird = require('bluebird');
+
+import { jsonEndpoint } from '../../../../route-helper/protectedEndpoint';
+import swagger from '../../../../swagger';
+import { number, verify } from '../../../../route-helper/schemaVerifier';
+import { AccountSummary } from '../../../../route-helper/getAccountPrivs';
+import { AccountPrivileges } from '../../../../route-helper/privileges';
+import { Tnex } from '../../../../tnex';
+import { dao } from '../../../../dao';
+import { BadRequestError } from '../../../../error/BadRequestError';
+import { UnauthorizedClientError } from '../../../../error/UnauthorizedClientError';
+import { getAccessTokenForCharacter } from '../../../../data-source/accessToken';
+
+
+export class Input {
+  character = number();
+  targetId = number();
+}
+const inputSchema = new Input();
+
+export interface Output {}
+
+
+/**
+ * Given a character and entity ID, opens the info window for that entity in the
+ * character's current game client. The requesting account must own the
+ * character.
+ */
+export default jsonEndpoint(
+    (req, res, db, account, privs): Bluebird<Output> => {
+  return Bluebird.resolve(
+      handleEndpoint(db, account, privs, verify(req.body, inputSchema)))
+});
+
+async function handleEndpoint(
+    db: Tnex, account: AccountSummary, privs: AccountPrivileges, input: Input) {
+
+  const row = await dao.character.getCoreData(db, input.character);
+  if (row == null) {
+    throw new BadRequestError(`No such character: ${input.character}.`);
+  }
+  if (row.account_id != account.id) {
+    throw new UnauthorizedClientError(
+        `Account ${account.id} doesn't own character ${input.character}.`);
+  }
+  // TODO: Catch errors below and throw a uservisible error
+  const accessToken = await getAccessTokenForCharacter(db, input.character);
+  await swagger.characters(input.character, accessToken)
+      .window.info(input.targetId);
+
+  return {};
+}

--- a/src/route/api/killmail/killmail_GET.ts
+++ b/src/route/api/killmail/killmail_GET.ts
@@ -1,0 +1,72 @@
+import Bluebird = require('bluebird');
+import _ = require('underscore');
+
+import { jsonEndpoint } from '../../../route-helper/protectedEndpoint';
+import { Tnex } from '../../../tnex';
+import { AccountPrivileges } from '../../../route-helper/privileges';
+import { idParam } from '../../../route-helper/paramVerifier';
+import { dao } from '../../../dao';
+import { NotFoundError } from '../../../error/NotFoundError';
+import swagger from '../../../swagger';
+import { ZKillmail, isPlayerAttacker, isStructureAttacker } from '../../../data-source/zkillboard/ZKillmail';
+import { SimpleNumMap, nil } from '../../../util/simpleTypes';
+import { fetchEveNames } from '../../../eve/names';
+
+
+export interface Output {
+  killmail: ZKillmail,
+  names: SimpleNumMap<string>,
+}
+
+
+/**
+ * Returns the data blob for a killmail as well as the names of any associated
+ * entities (participants, items, etc.).
+ */
+export default jsonEndpoint((req, res, db, account, privs): Bluebird<Output> => {
+  const killmailId = idParam(req, 'id');
+
+  return Bluebird.resolve(handleEndpoint(db, privs, killmailId));
+});
+
+async function handleEndpoint(
+    db: Tnex, privs: AccountPrivileges, killmailId: number) {
+
+  const row = await dao.killmail.getKillmail(db, killmailId);
+  if (row == null) {
+    throw new NotFoundError();
+  }
+
+  const names = await buildNameMap(row.km_data);
+
+  return {
+    killmail: row.km_data,
+    names: names,
+  };
+}
+
+async function buildNameMap(mail: ZKillmail) {
+  const unnamedIds = new Set<number | nil>();
+  unnamedIds.add(mail.solar_system_id);
+  unnamedIds.add(mail.victim.character_id);
+  unnamedIds.add(mail.victim.corporation_id);
+  unnamedIds.add(mail.victim.alliance_id!);
+  unnamedIds.add(mail.victim.ship_type_id);
+
+  for (let item of mail.victim.items) {
+    unnamedIds.add(item.item_type_id);
+  }
+  for (let attacker of mail.attackers) {
+    unnamedIds.add(attacker.ship_type_id!);
+
+    if (isPlayerAttacker(attacker)) {
+      unnamedIds.add(attacker.character_id);
+      unnamedIds.add(attacker.corporation_id);
+      unnamedIds.add(attacker.alliance_id!);
+      unnamedIds.add(attacker.weapon_type_id);
+    } else if (isStructureAttacker(attacker)) {
+      unnamedIds.add(attacker.corporation_id);
+    }
+  }
+  return await fetchEveNames(unnamedIds);
+}

--- a/src/route/api/srp/loss/loss_PUT.ts
+++ b/src/route/api/srp/loss/loss_PUT.ts
@@ -1,0 +1,60 @@
+import Bluebird = require('bluebird');
+
+import { jsonEndpoint } from '../../../../route-helper/protectedEndpoint';
+import { number, verify, string, nullable, stringEnum } from '../../../../route-helper/schemaVerifier';
+import { AccountSummary } from '../../../../route-helper/getAccountPrivs';
+import { AccountPrivileges } from '../../../../route-helper/privileges';
+import { Tnex } from '../../../../tnex';
+import { dao } from '../../../../dao';
+import { BadRequestError } from '../../../../error/BadRequestError';
+import { SrpVerdictStatus, SrpVerdictReason } from '../../../../dao/enums';
+import { NotFoundError } from '../../../../error/NotFoundError';
+import { idParam } from '../../../../route-helper/paramVerifier';
+
+export class Input {
+  verdict = stringEnum<SrpVerdictStatus>(SrpVerdictStatus);
+  reason = nullable(stringEnum<SrpVerdictReason>(SrpVerdictReason));
+  payout = number();
+}
+const inputSchema = new Input();
+
+export interface Output {}
+
+
+/**
+ * Sets the SRP verdict for a particular loss (i.e. approved or ineligible).
+ */
+export default jsonEndpoint(
+    (req, res, db, account, privs): Bluebird<Output> => {
+
+  return Bluebird.resolve(handleEndpoint(
+      db, account, privs, idParam(req, 'id'), verify(req.body, inputSchema)))
+});
+
+async function handleEndpoint(
+    db: Tnex,
+    account: AccountSummary,
+    privs: AccountPrivileges,
+    id: number,
+    input: Input,
+) {
+  privs.requireWrite('srp');
+
+  if (input.verdict == SrpVerdictStatus.INELIGIBLE && input.reason == null) {
+    throw new BadRequestError(
+        `Reason must be specified if status is ineligible.`);
+  }
+  if (input.verdict != SrpVerdictStatus.INELIGIBLE && input.reason != null) {
+    throw new BadRequestError(
+        `Reason must be null if status not ineligible.`);
+  }
+
+  const updateCount = await dao.srp.setSrpVerdict(
+      db, id, input.verdict, input.reason, input.payout, account.id)
+
+  if (updateCount != 1) {
+    throw new NotFoundError();
+  }
+
+  return {};
+}

--- a/src/route/api/srp/loss/loss_dir_GET.ts
+++ b/src/route/api/srp/loss/loss_dir_GET.ts
@@ -1,0 +1,81 @@
+import Bluebird = require('bluebird');
+import moment = require('moment');
+
+import { jsonEndpoint } from '../../../../route-helper/protectedEndpoint';
+import { Tnex } from '../../../../tnex/Tnex';
+import { AccountPrivileges } from '../../../../route-helper/privileges';
+import { dao } from '../../../../dao';
+import { SrpVerdictStatus } from '../../../../dao/enums';
+import { SimpleNumMap, nil } from '../../../../util/simpleTypes';
+import { boolQuery, intQuery, enumQuery } from '../../../../route-helper/paramVerifier';
+import { findWhere } from '../../../../util/underscore';
+import { fetchEveNames } from '../../../../eve/names';
+import { srpLossToJson } from '../../../../srp/srpLossToJson';
+import { SrpLossFilter, SrpLossRow } from '../../../../dao/SrpDao';
+import { ResultOrder } from '../../../../tnex';
+import { SrpLossJson, SrpTriageJson } from '../../../../srp/SrpLossJson';
+
+
+export interface Output {
+  srps: SrpLossJson[],
+  names: SimpleNumMap<string>,
+}
+
+
+/**
+ * Returns a list of losses and their associated SRP verdict and payment status.
+ * Supports a wide variety of filters.
+ */
+export default jsonEndpoint((req, res, db, account, privs): Bluebird<Output> => {
+
+  return Bluebird.resolve(
+      handleEndpoint(
+          db,
+          privs,
+          {
+            status: boolQuery(req, 'pending')
+                ? SrpVerdictStatus.PENDING : undefined,
+            limit: intQuery(req, 'limit'),
+            order: enumQuery<ResultOrder>(req, 'order', ResultOrder),
+            fromKillmail: intQuery(req, 'fromKillmail'),
+            account: intQuery(req, 'account'),
+            character: intQuery(req, 'character'),
+          },
+          boolQuery(req, 'includeTriage') || false,
+      )
+  );
+});
+
+const DEFAULT_ROWS_PER_QUERY = 30;
+const MAX_ROWS_PER_QUERY = 100;
+
+async function handleEndpoint(
+    db: Tnex,
+    privs: AccountPrivileges,
+    filter: SrpLossFilter,
+    includeTriage: boolean,
+) {
+  privs.requireRead('srp');
+
+  filter.limit =
+      Math.min(MAX_ROWS_PER_QUERY, filter.limit || DEFAULT_ROWS_PER_QUERY);
+
+  const unresolvedIds = new Set<number | nil>();
+
+  const rows = await dao.srp.listSrps(db, filter);
+  let srps = rows.map(row => srpLossToJson(row, unresolvedIds));
+
+  if (includeTriage) {
+    // NEXT PR: Calculate loss triage
+    for (let srp of srps) {
+      // NEXT PR: Set loss triage here
+    }
+  }
+
+  const resolvedIds = await fetchEveNames(unresolvedIds);
+
+  return {
+    srps: srps,
+    names: resolvedIds,
+  };
+}

--- a/src/route/api/srp/payment/payment_GET.ts
+++ b/src/route/api/srp/payment/payment_GET.ts
@@ -1,0 +1,70 @@
+import Bluebird = require('bluebird');
+import moment = require('moment');
+
+import { jsonEndpoint } from '../../../../route-helper/protectedEndpoint';
+import { Tnex } from '../../../../tnex';
+import { AccountPrivileges } from '../../../../route-helper/privileges';
+import { idParam } from '../../../../route-helper/paramVerifier';
+import { dao } from '../../../../dao';
+import { NotFoundError } from '../../../../error/NotFoundError';
+import swagger from '../../../../swagger';
+import { SimpleNumMap } from '../../../../util/simpleTypes';
+import { srpLossToJson } from '../../../../srp/srpLossToJson';
+import { fetchEveNames } from '../../../../eve/names';
+import { SrpLossJson } from '../../../../srp/SrpLossJson';
+
+export interface Output {
+  payment: {
+    recipient: number,
+    modified: number,
+    modifiedLabel: string,
+    paid: boolean,
+    payer: number | null,
+  },
+  losses: SrpLossJson[],
+  names: SimpleNumMap<string>,
+}
+
+
+/**
+ * Return information about a SRP reimbursement as well as all of its associated
+ * approved losses.
+ */
+export default jsonEndpoint((req, res, db, account, privs): Bluebird<Output> => {
+  const paymentId = idParam(req, 'id');
+
+  return Bluebird.resolve(handleEndpoint(db, privs, paymentId));
+});
+
+async function handleEndpoint(
+    db: Tnex, privs: AccountPrivileges, paymentId: number) {
+  privs.requireRead('srp');
+
+  const reimbRow = await dao.srp.getReimbursement(db, paymentId);
+
+  if (reimbRow == null) {
+    throw new NotFoundError();
+  }
+
+  const lossRows = await dao.srp.listSrps(db, { reimbursement: paymentId });
+
+  const ids = new Set<number | null>();
+  ids.add(reimbRow.srpr_recipientCharacter);
+  ids.add(reimbRow.srpr_payingCharacter);
+
+  const losses = lossRows.map(row => srpLossToJson(row, ids));
+  const names = await fetchEveNames(ids);
+
+  return {
+    payment: {
+      recipient: reimbRow.srpr_recipientCharacter,
+      modified: reimbRow.srpr_modified,
+      modifiedLabel:
+          moment.utc(reimbRow.srpr_modified).format('YYYY-MM-DD HH:mm'),
+      paid: reimbRow.srpr_paid,
+      payer: reimbRow.srpr_payingCharacter,
+    },
+    losses: losses,
+    names: names,
+  }
+}

--- a/src/route/api/srp/payment/payment_PUT.ts
+++ b/src/route/api/srp/payment/payment_PUT.ts
@@ -1,0 +1,57 @@
+import Bluebird = require('bluebird');
+
+import { jsonEndpoint } from '../../../../route-helper/protectedEndpoint';
+import { number, verify, string, nullable, stringEnum, boolean, optional } from '../../../../route-helper/schemaVerifier';
+import { AccountSummary } from '../../../../route-helper/getAccountPrivs';
+import { AccountPrivileges } from '../../../../route-helper/privileges';
+import { Tnex } from '../../../../tnex';
+import { dao } from '../../../../dao';
+import { BadRequestError } from '../../../../error/BadRequestError';
+import { SrpVerdictStatus } from '../../../../dao/enums';
+import { NotFoundError } from '../../../../error/NotFoundError';
+import { idParam } from '../../../../route-helper/paramVerifier';
+
+export class Input {
+  paid = boolean();
+  payingCharacter = optional(number());
+}
+const inputSchema = new Input();
+
+export interface Output {}
+
+
+/**
+ * Marks a reimbursement as paid (or unpaid).
+ */
+export default jsonEndpoint((req, res, db, account, privs): Bluebird<Output> => {
+
+  return Bluebird.resolve(handleEndpoint(
+      db, account, privs, idParam(req, 'id'), verify(req.body, inputSchema)))
+});
+
+async function handleEndpoint(
+    db: Tnex,
+    account: AccountSummary,
+    privs: AccountPrivileges,
+    id: number,
+    input: Input,
+) {
+  privs.requireWrite('srp');
+
+  let updateCount;
+  if (input.paid) {
+    if (input.payingCharacter == undefined) {
+      throw new BadRequestError(`Missing payingCharacter field.`);
+    }
+    updateCount =
+        await dao.srp.markReimbursementAsPaid(db, id, input.payingCharacter);
+  } else {
+    updateCount = await dao.srp.markReimbursementAsUnpaid(db, id);
+  }
+
+  if (updateCount != 1) {
+    throw new NotFoundError();
+  }
+
+  return {};
+}

--- a/src/route/api/srp/payment/payment_dir_GET.ts
+++ b/src/route/api/srp/payment/payment_dir_GET.ts
@@ -1,0 +1,100 @@
+import Bluebird = require('bluebird');
+import moment = require('moment');
+
+import { jsonEndpoint } from '../../../../route-helper/protectedEndpoint';
+import { AccountSummary } from '../../../../route-helper/getAccountPrivs';
+import { AccountPrivileges } from '../../../../route-helper/privileges';
+import { Tnex, ResultOrder } from '../../../../tnex';
+import { dao } from '../../../../dao';
+import { BadRequestError } from '../../../../error/BadRequestError';
+import { idParam, boolQuery, intQuery, enumQuery } from '../../../../route-helper/paramVerifier';
+import { nil, SimpleNumMap } from '../../../../util/simpleTypes';
+import { fetchEveNames } from '../../../../eve/names';
+import { SrpReimbursementFilter } from '../../../../dao/SrpDao';
+
+export interface Output {
+  payments: PaymentJson[],
+  names: SimpleNumMap<string>,
+}
+
+export interface PaymentJson {
+  id: number,
+  modified: number,
+  modifiedStr: string,
+  totalPayout: number,
+  totalLosses: number,
+  recipient: number,
+  recipientCorp: number | null,
+  payer: number | null,
+  payerCorp: number | null,
+}
+
+export enum OrderBy {
+  ID = 'id',
+  MODIFIED = 'modified',
+}
+
+
+/**
+ * Returns a list of recent payments. Query can be filtered in a number of ways.
+ */
+export default jsonEndpoint((req, res, db, account, privs): Bluebird<Output> => {
+  return Bluebird.resolve(
+      handleEndpoint(
+          db,
+          account,
+          privs,
+          {
+            paid: boolQuery(req, 'paid'),
+            account: intQuery(req, 'account'),
+            limit: intQuery(req, 'limit'),
+            order: enumQuery<ResultOrder>(req, 'order', ResultOrder)
+                || ResultOrder.DESC,
+            orderBy: enumQuery<OrderBy>(req, 'orderBy', OrderBy) || OrderBy.ID,
+            startingAfter: intQuery(req, 'startingAfter'),
+          }));
+});
+
+const DEFAULT_ROWS_PER_QUERY = 30;
+const MAX_ROWS_PER_QUERY = 100;
+
+async function handleEndpoint(
+    db: Tnex,
+    account: AccountSummary,
+    privs: AccountPrivileges,
+    filter: SrpReimbursementFilter,
+) {
+  privs.requireRead('srp');
+
+  filter.limit = Math.min(
+      MAX_ROWS_PER_QUERY, filter.limit || DEFAULT_ROWS_PER_QUERY);
+
+  const rows = await dao.srp.listReimbursements(db, filter);
+
+  const ids = new Set<number | nil>();
+  const payments: PaymentJson[] = rows.map(row => {
+    ids.add(row.srpr_recipientCharacter);
+    ids.add(row.character_corporationId);
+    ids.add(row.srpr_payingCharacter);
+    ids.add(row.payingChar_corporationId);
+
+    return {
+      id: row.srpr_id,
+      modified: row.srpr_modified,
+      modifiedStr: moment.utc(row.srpr_modified).format('YYYY-MM-DD HH:mm'),
+      totalPayout: row.combined_payout,
+      totalLosses: row.combined_losses,
+      recipient: row.srpr_recipientCharacter,
+      recipientCorp: row.character_corporationId,
+      payer: row.srpr_payingCharacter,
+      payerCorp: row.payingChar_corporationId,
+    };
+  });
+
+  const names = await fetchEveNames(ids);
+
+  return {
+    payments: payments,
+    names: names,
+  };
+}

--- a/src/route/home.ts
+++ b/src/route/home.ts
@@ -9,9 +9,11 @@ export default htmlEndpoint((req, res, db, account, privs) => {
         [
           'roster',
           'adminConsole',
+          'srp',
         ],
         false
     ),
+    isMember: privs.isMember(),
   };
 
   return {

--- a/src/srp/SrpLossJson.ts
+++ b/src/srp/SrpLossJson.ts
@@ -1,0 +1,61 @@
+import { SrpVerdictStatus, SrpVerdictReason } from "../dao/enums";
+import { Nullable } from "../util/simpleTypes";
+
+
+/**
+ * JSON format for corp ship losses. Combines killmail information with SRP
+ * information and an optional set of triage suggestions.
+ */
+export interface SrpLossJson {
+  killmail: number,
+  timestamp: string,
+  shipType: number,
+  victim: number,
+  victimCorp: number,
+  executioner: AttackerJson,
+  relatedKillmail: {
+    id: number | null,
+    shipId: number | null,
+  } | null,
+  status: UnifiedSrpLossStatus,
+  reason: SrpVerdictReason | null,
+  payout: number,
+  reimbursement: number | null,
+  payingCharacter: number | null,
+  triage: SrpTriageJson | null,
+}
+
+export interface SrpTriageJson {
+  extraOptions: VerdictOptionJson[],
+  suggestedOption: string,
+}
+
+export interface VerdictOptionJson {
+  label: string,
+  key: string,
+  payout: number,
+  verdict: SrpVerdictStatus,
+}
+
+export type AttackerJson =
+    PlayerAttackerJson | StructureAttackerJson | NpcAttackerJson;
+
+export interface PlayerAttackerJson {
+  type: 'player',
+  character: number,
+  corporation: number,
+  alliance: number | undefined,
+}
+
+export interface StructureAttackerJson {
+  type: 'structure',
+  ship: number | undefined,
+  corporation: number,
+}
+
+export interface NpcAttackerJson {
+  type: 'npc',
+  ship: number | undefined,
+}
+
+export type UnifiedSrpLossStatus = SrpVerdictStatus | 'paid';

--- a/src/srp/srpLossToJson.ts
+++ b/src/srp/srpLossToJson.ts
@@ -1,0 +1,82 @@
+const moment = require('moment');
+
+import { SrpLossRow } from "../dao/SrpDao";
+import { nil } from "../util/simpleTypes";
+import { ZKillmail, isPlayerAttacker, isStructureAttacker } from "../data-source/zkillboard/ZKillmail";
+import { findWhere } from "../util/underscore";
+import { SrpVerdictStatus } from "../dao/enums";
+import { SrpLossJson, UnifiedSrpLossStatus, PlayerAttackerJson, NpcAttackerJson, AttackerJson } from "./SrpLossJson";
+
+
+/**
+ * Shared logic for dumping the representation of an SRPable loss to JSON.
+ * The "triage" field in the resulting JSON will always be null; it's up to
+ * the caller to fill this in if necessary.
+ *
+ * @param ids Will add any IDs that need names into this set.
+ */
+export function srpLossToJson(
+    row: SrpLossRow, ids: Set<number | nil>): SrpLossJson {
+  const json: SrpLossJson = {
+    killmail: row.km_id,
+    timestamp: moment.utc(row.km_timestamp).format('YYYY-MM-DD HH:mm'),
+    shipType: row.km_data.victim.ship_type_id,
+    victim: row.km_data.victim.character_id,
+    victimCorp: row.km_data.victim.corporation_id,
+    relatedKillmail: row.related_data ? {
+      id: row.related_data.killmail_id,
+      shipId: row.related_data.victim.ship_type_id,
+    } : null,
+    executioner: getExecutioner(row.km_data, ids),
+    status: row.srpr_paid == true ?
+        <UnifiedSrpLossStatus>'paid' : row.srpv_status,
+    reason: row.srpv_reason,
+    payout: row.srpv_payout,
+    reimbursement: row.srpr_id,
+    payingCharacter: row.srpr_payingCharacter,
+    triage: null,
+  }
+
+  ids.add(json.shipType);
+  ids.add(json.victim);
+  ids.add(json.victimCorp);
+  ids.add(row.srpr_payingCharacter);
+
+  return json;
+}
+
+function getExecutioner(
+    mail: ZKillmail, ids: Set<number | nil>,
+): AttackerJson {
+  const executioner = findWhere(mail.attackers, { final_blow: true })!;
+  if (isPlayerAttacker(executioner)) {
+    ids.add(executioner.character_id);
+    ids.add(executioner.corporation_id);
+    if (executioner.alliance_id != null) {
+      ids.add(executioner.alliance_id);
+    }
+
+    return {
+      type: 'player',
+      character: executioner.character_id,
+      corporation: executioner.corporation_id,
+      alliance: executioner.alliance_id,
+    };
+  } else if (isStructureAttacker(executioner)) {
+    ids.add(executioner.ship_type_id)
+    ids.add(executioner.corporation_id);
+
+    return {
+      type: 'structure',
+      corporation: executioner.corporation_id,
+      ship: executioner.ship_type_id,
+    }
+  } else {
+    ids.add(executioner.ship_type_id);
+
+    return {
+      type: 'npc',
+      ship: executioner.ship_type_id,
+    };
+  }
+}

--- a/src/util/simpleTypes.ts
+++ b/src/util/simpleTypes.ts
@@ -1,5 +1,9 @@
 export type nil = null | undefined;
 
+export type Nullable<T>  = {
+  [P in keyof T]: T[P] | null
+};
+
 export type BasicType = number | boolean | string | object;
 
 export type SimpleMap<T> = {


### PR DESCRIPTION
- Adds tables to track verdicts (whether loss should be reimbursed) and reimbursements (which might be more multiple losses at the same time).
- Adds REST endpoints for reading and writing to these tables.
- Adds a couple other REST endpoints for use by the SRP triage flow: an endpoint to list all characters that can perform SRP payments and an endpoint to open UI windows for members that need to be paid.