### PR TITLE
Tnex: add support for joins in updates

### DIFF
--- a/src/dao/CharacterDao.ts
+++ b/src/dao/CharacterDao.ts
@@ -1,7 +1,7 @@
 import Promise = require('bluebird');
 
 import { Dao } from '../dao';
-import { Tnex, Nullable, val } from '../tnex';
+import { Tnex, val } from '../tnex';
 import {
     accessToken,
     account,
@@ -143,7 +143,7 @@ export default class CharacterDao {
   getMemberCharacters(db: Tnex) {
     return db
         .select(memberCorporation)
-        .join(character, 
+        .join(character,
             'character_corporationId',
             '=',
             'memberCorporation_corporationId')

--- a/src/dao/CharacterLocationDao.ts
+++ b/src/dao/CharacterLocationDao.ts
@@ -1,7 +1,7 @@
 import Promise = require('bluebird');
 
 import { Dao } from '../dao';
-import { Tnex, Nullable, toNum, val } from '../tnex';
+import { Tnex, toNum, val } from '../tnex';
 import { characterLocation, CharacterLocation } from './tables';
 
 export default class LocationDao {

--- a/src/dao/OwnershipDao.ts
+++ b/src/dao/OwnershipDao.ts
@@ -1,6 +1,6 @@
 import Promise = require('bluebird');
 
-import { Tnex, Nullable, val } from '../tnex';
+import { Tnex, val } from '../tnex';
 import { Dao } from '../dao';
 import { account, character, ownership, pendingOwnership } from './tables';
 import { updateGroupsForAccount } from '../data-source/accountGroups';
@@ -108,7 +108,7 @@ export default class OwnershipDao {
         .join(character, 'character_id', '=', 'pendingOwnership_character')
         .where('pendingOwnership_account', '=', val(accountId))
         .columns(
-            'pendingOwnership_character', 
+            'pendingOwnership_character',
             'character_name',
             )
         .run();

--- a/src/route/authenticate.ts
+++ b/src/route/authenticate.ts
@@ -6,7 +6,7 @@ import axios from 'axios';
 import express = require('express');
 
 import { dao } from '../dao';
-import { Tnex, Nullable } from '../tnex';
+import { Tnex } from '../tnex';
 import { isAnyEsiError } from '../util/error';
 
 import swagger from '../swagger';

--- a/src/tnex/Query.ts
+++ b/src/tnex/Query.ts
@@ -9,15 +9,12 @@ export class Query<T extends object, R /* return type */> {
   protected _scoper: Scoper;
   protected _query: Knex.QueryBuilder;
 
-  private _wasRun = false;
-
-  constructor(scoper: Scoper, query: Knex.QueryBuilder, shouldBeRun: boolean) {
+  constructor(scoper: Scoper, query: Knex.QueryBuilder) {
     this._scoper = scoper;
     this._query = query;
   }
 
   public run(): Promise<R> {
-    this._wasRun = true;
     return this._query;
   }
 
@@ -103,12 +100,5 @@ export class Query<T extends object, R /* return type */> {
         .whereIn(this._scoper.scopeColumn(column), values);
 
     return this;
-  }
-
-  public assertWasRun() {
-    if (!this._wasRun) {
-      throw new Error(`The following query was created but not run:`
-          + ` ${this._query.toString()}`);
-    }
   }
 }

--- a/src/tnex/Tnex.ts
+++ b/src/tnex/Tnex.ts
@@ -5,9 +5,10 @@ import Knex = require('knex');
 
 import { ValueWrapper, ColumnType, SimpleObj, val } from './core';
 import { Scoper } from './Scoper';
-import { Joiner } from './Joiner';
+import { Select } from './Select';
 import { Query } from './Query';
 import { RenamedJoin } from './RenamedJoin';
+import { Update } from './Update';
 
 const USE_DEFAULT = {};
 
@@ -61,12 +62,12 @@ export class Tnex {
     }
   }
 
-  public select<T extends object>(table: T): Joiner<T, {}> {
-    return new Joiner<T, {}>(this._knex, this._registry, table);
+  public select<T extends object>(table: T): Select<T, {}> {
+    return new Select<T, {}>(this._knex, this._registry, table);
   }
 
   public subselect<T extends object>(startingTable: T, asTableName: string) {
-    return new Joiner<T, {}>(
+    return new Select<T, {}>(
         this._knex,
         this._registry,
         startingTable,
@@ -134,21 +135,16 @@ export class Tnex {
   public update<T extends object>(
     table: T,
     values: Partial<T>,
-    ): Query<T, number> {
-
-    return new Query<T, number>(
-        this._registry,
-        this._knex(this._registry.getTableName(table))
-            .update(this._prepForInsert(values, table)),
-        true);
+  ): Update<T, {}> {
+    return new Update(
+        this._knex, this._registry, table, this._prepForInsert(values, table));
   }
 
   public del<T extends object>(table: T): Query<T, number> {
     return new Query<T, number>(
         this._registry,
         this._knex(this._registry.getTableName(table))
-            .del(),
-        true);
+            .del());
   }
 
   /**

--- a/src/tnex/Update.ts
+++ b/src/tnex/Update.ts
@@ -1,0 +1,61 @@
+import Bluebird = require('bluebird');
+import Knex = require('knex');
+
+import { Query } from './Query';
+import { Scoper } from './Scoper';
+
+
+/**
+ * Represents an update query in Tnex.
+ */
+export class Update<T extends object, F extends object>
+    extends Query<T & F, number> {
+
+  private _knex: Knex;
+  private _fromTables: object[] = [];
+
+  constructor(
+      knex: Knex,
+      scoper: Scoper,
+      table: T,
+      preppedValues: object,
+      ) {
+    super(
+        scoper.mirror(),
+        knex(scoper.getTableName(table))
+            .update(preppedValues));
+    this._knex = knex;
+  }
+
+  /**
+   * Join another table to the update query. One of your where() clauses should
+   * specify how the join is performed, e.g.
+   * .where('fromTable_foo', '=', 'baseTable_bar')
+   */
+  public from<S extends object>(table: S): Update<T, F & S> {
+    this._fromTables.push(table);
+    return this;
+  }
+
+  public run(): Bluebird<number> {
+    if (this._fromTables.length == 0) {
+      return super.run();
+    } else {
+      const tableQs = new Array(this._fromTables.length).fill('??').join(',');
+      const tableNames = this._fromTables.map(
+          table => this._scoper.getTableName(table));
+      const fromClause = this._knex.raw(tableQs, tableNames);
+
+      const modifiedQuery = this._query.toString()
+          .replace(
+              ` where `,
+              ` from ${fromClause} where `);
+
+      return this._knex.raw(modifiedQuery)
+      .then(response => {
+        console.log('Response!', response);
+        return 0;
+      });
+    }
+  }
+}

--- a/src/tnex/core.ts
+++ b/src/tnex/core.ts
@@ -21,6 +21,10 @@ export type SimpleObj = {
   [key: string]: any
 };
 
+export type Nullable<T>  = {
+  [P in keyof T]: T[P] | null
+};
+
 export class ValueWrapper<T extends ColumnType> {
   constructor(
       public value: T,

--- a/src/tnex/definers.ts
+++ b/src/tnex/definers.ts
@@ -23,6 +23,6 @@ export function enu<K extends string>(): K {
   return '' as K;
 }
 
-export function json<K extends object>(): K {
+export function json<K>(): K {
   return {} as K;
 }

--- a/src/tnex/index.ts
+++ b/src/tnex/index.ts
@@ -1,8 +1,7 @@
 export { TnexBuilder } from './TnexBuilder';
 
-export { val, ResultOrder, } from './core';
+export { val, ResultOrder } from './core';
 export { Tnex } from './Tnex';
-export { Nullable } from './Joiner';
 export { nullable, number, string, boolean, boolinum, enu, json } from './definers';
 
 export {


### PR DESCRIPTION
- Adds the ability to perform joins during updates (Postgres only).
- Renames Joiner to Select
- Removes external dependency on Nullable type.
- Removes some vestigial wasRun() checking code in Query.