### PR TITLE
Fix incorrect conditional for empty account deletion

### DIFF
--- a/src/dao/AccountDao.ts
+++ b/src/dao/AccountDao.ts
@@ -142,7 +142,7 @@ export default class AccountDao {
           .where('ownership_account', '=', val(accountId))
           .fetchFirst()
       .then(row => {
-        if (row != null && row.ownedCount == 0) {
+        if (row != null && row.ownedCount > 0) {
             return 0; // Not empty, don't delete
         }
 


### PR DESCRIPTION
As written we try to delete "empty" accounts only if they own a *nonzero* number of characters. That's backwards.