### PR TITLE
Fix a couple of setup-related bugs

### DIFF
--- a/src/dao/ConfigDao.ts
+++ b/src/dao/ConfigDao.ts
@@ -44,8 +44,7 @@ export default class ConfigDao {
   set(db: Tnex, values: Nullable<Partial<ConfigEntries>>) {
     return serialize(Object.keys(values), key => {
       const value = (values as any)[key];
-      let transformedValue =
-          value instanceof Array ? JSON.stringify(value) : value;
+      let transformedValue = JSON.stringify(value);
       return db
           .update(config, { config_value: transformedValue })
           .where('config_key', '=', val(key))

--- a/src/route-helper/schemaVerifier.ts
+++ b/src/route-helper/schemaVerifier.ts
@@ -203,7 +203,7 @@ class ArraySchema extends Schema {
   constructor(
       private _subSchema: Schema,
       ) {
-    super('string');
+    super('object');
   }
 
   verify(value: any, path: string[]) {


### PR DESCRIPTION
- Always stringify config values before setting them. The postgres
connection can't auto-stringify non-object, non-array values.
- Fix schema type for arrays (how did this ever work..)