### PR TITLE
Upgrade packages, including TS2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": "8.9.3"
+    "node": "10.4.1"
   },
   "dependencies": {
     "@types/bluebird": "^3.5.3",
@@ -22,7 +22,7 @@
     "@types/cookie-session": "^2.0.32",
     "@types/express": "^4.0.35",
     "@types/knex": "^0.14.3",
-    "@types/node": "^9.3.0",
+    "@types/node": "^10.3.4",
     "@types/node-schedule": "^1.2.2",
     "@types/pg": "^7.4.1",
     "@types/sqlite3": "^3.1.0",
@@ -30,8 +30,8 @@
     "@types/tough-cookie": "^2.3.0",
     "@types/underscore": "^1.8.7",
     "@types/webpack": "^3.8.3",
-    "@types/xml2js": "0.4.2",
-    "axios": "^0.17.1",
+    "@types/xml2js": "0.4.3",
+    "axios": "^0.18.0",
     "babel-core": "^6.0.0",
     "babel-loader": "^7.1.2",
     "babel-preset-es2015": "^6.0.0",
@@ -57,11 +57,11 @@
     "scribe-js": "^2.0.4",
     "soupselect": "^0.2.0",
     "source-map-support": "^0.5.2",
-    "sqlite3": "^3.1.8",
+    "sqlite3": "^4.0.0",
     "strip-json-comments": "^2.0.1",
     "tmp": "0.0.33",
     "tough-cookie": "^2.3.2",
-    "typescript": "^2.3.2",
+    "typescript": "^2.9.2",
     "unbzip2-stream": "^1.2.5",
     "underscore": "^1.8.3",
     "vue": "^2.5.0",
@@ -72,8 +72,8 @@
     "xml2js": "^0.4.2"
   },
   "devDependencies": {
-    "@types/jest": "^22.1.0",
-    "jest": "^22.1.4",
+    "@types/jest": "^23.1.1",
+    "jest": "^23.1.0",
     "ts-jest": "^22.0.1",
     "webpack-dev-middleware": "^2.0.4",
     "webpack-hot-middleware": "^2.17.0"

--- a/src/tnex/Query.ts
+++ b/src/tnex/Query.ts
@@ -1,7 +1,7 @@
 import Promise = require('bluebird');
 import Knex = require('knex');
 
-import { ColumnType, Comparison, ValueWrapper } from './core';
+import { ColumnType, Comparison, ValueWrapper, StringKeyOf } from './core';
 import { Scoper } from './Scoper';
 
 
@@ -26,7 +26,7 @@ export class Query<T extends object, R /* return type */> {
    * knex handles value bindings in its generated queries.
    */
 
-  public where<K1 extends keyof T, K2 extends keyof T>(
+  public where<K1 extends StringKeyOf<T>, K2 extends StringKeyOf<T>>(
       column: K1,
       cmp: Comparison,
       right: K2 | ValueWrapper<T[K1] & ColumnType>,
@@ -52,7 +52,7 @@ export class Query<T extends object, R /* return type */> {
     return this;
   }
 
-  public andWhere<K1 extends keyof T, K2 extends keyof T>(
+  public andWhere<K1 extends StringKeyOf<T>, K2 extends StringKeyOf<T>>(
       column: K1,
       cmp: Comparison,
       right: K2 | ValueWrapper<T[K1] & ColumnType>,
@@ -63,7 +63,7 @@ export class Query<T extends object, R /* return type */> {
     return this.where(column, cmp, right);
   }
 
-  public orWhere<K1 extends keyof T, K2 extends keyof T>(
+  public orWhere<K1 extends StringKeyOf<T>, K2 extends StringKeyOf<T>>(
       column: K1,
       cmp: Comparison,
       right: K2 | ValueWrapper<T[K1] & ColumnType>,
@@ -80,21 +80,21 @@ export class Query<T extends object, R /* return type */> {
     return this;
   }
 
-  public whereNotNull(column: keyof T): this {
+  public whereNotNull(column: StringKeyOf<T>): this {
     this._query = this._query
         .whereNotNull(this._scoper.scopeColumn(column));
 
     return this;
   }
 
-  public whereNull(column: keyof T): this {
+  public whereNull(column: StringKeyOf<T>): this {
     this._query = this._query
         .whereNull(this._scoper.scopeColumn(column));
 
     return this;
   }
 
-  public whereIn<K extends keyof T>(
+  public whereIn<K extends StringKeyOf<T>>(
       column: K, values: T[K][] & ColumnType[]): this {
     this._query = this._query
         .whereIn(this._scoper.scopeColumn(column), values);

--- a/src/tnex/Tnex.ts
+++ b/src/tnex/Tnex.ts
@@ -3,7 +3,7 @@ import { inspect } from 'util';
 import Bluebird = require('bluebird');
 import Knex = require('knex');
 
-import { SimpleObj, val } from './core';
+import { SimpleObj, val, StringKeyOf } from './core';
 import { Scoper } from './Scoper';
 import { Select } from './Select';
 import { Query } from './Query';
@@ -141,7 +141,7 @@ export class Tnex {
    * Updates multiple rows at once. Rows must have a unique ID column (as
    * specified in the `idColumn` parameter).
    */
-  public updateAll<T extends object, K extends keyof T>(
+  public updateAll<T extends object, K extends StringKeyOf<T>>(
       table: T,
       idColumn: K,
       rows: Array<Partial<T> & Pick<T, K>>,
@@ -161,7 +161,7 @@ export class Tnex {
 
     const query: string[] = [];
     const bindings: string[] = [];
-    const cols: (keyof T)[] = [idColumn];
+    const cols: StringKeyOf<T>[] = [idColumn];
 
     query.push(`UPDATE ?? SET`);
     bindings.push(tableName);
@@ -235,7 +235,7 @@ export class Tnex {
   public upsert<T extends object, R extends T>(
       table: T,
       row: R,
-      primaryColumn: keyof T,
+      primaryColumn: StringKeyOf<T>,
       updateStrategy?: UpdateStrategy<Partial<T>>,
   ): Bluebird<number> {
     return this.upsertAll(table, [row], primaryColumn, updateStrategy);
@@ -254,7 +254,7 @@ export class Tnex {
   public upsertAll<T extends object, R extends T>(
       table: T,
       rows: R[],
-      primaryColumn: keyof T,
+      primaryColumn: StringKeyOf<T>,
       updateStrategy?: UpdateStrategy<Partial<T>>,
   ): Bluebird<number> {
     if (rows.length == 0) {
@@ -263,7 +263,7 @@ export class Tnex {
 
     const clientType = (this._rootKnex as any).CLIENT as string;
     const tableName = this._registry.getTableName(table);
-    const colNames = Object.keys(table) as (keyof T)[];
+    const colNames = Object.keys(table) as StringKeyOf<T>[];
 
     if (clientType == 'pg') {
       const queryArgs: any[] = [tableName];
@@ -333,7 +333,7 @@ export class Tnex {
   // TODO: add "primary" or "principle" column annotations to Tnex so that we
   // don't have to ask what the important column in question is -- and, more
   // importantly, so we can enforce that there's only one per table.
-  public replace<T extends object, K extends keyof T>(
+  public replace<T extends object, K extends StringKeyOf<T>>(
       table: T,
       sharedColumn: K,
       sharedColumnValue: T[K] & number,

--- a/src/tnex/core.ts
+++ b/src/tnex/core.ts
@@ -17,6 +17,16 @@ export type Link<T, K extends keyof T, L extends string> = {
   [P in L]: T[K]
 };
 
+/**
+ * All of the string keys of a type. Essentially `keyof <type>` but only
+ * includes the string keys.
+ *
+ * Since TS 2.9, `keyof <type>` has a type of `string | number | Symbol`. Tnex
+ * only works on string properties; this allows those functions to restrict
+ * their parameters to only accept string properties.
+ */
+export type StringKeyOf<T> = Extract<keyof T, string>;
+
 export type SimpleObj = {
   [key: string]: any
 };

--- a/src/util/underscore.ts
+++ b/src/util/underscore.ts
@@ -9,7 +9,7 @@ export function pluck<T, K extends keyof T>(
     list: T[],
     property: K,
     ): Array<T[K]> {
-  return _.pluck(list, property);
+  return _.pluck(list, property as string);
 }
 
 export function findWhere<T>(list: T[], properties: Partial<T>): T | undefined {


### PR DESCRIPTION
Typescript 2.9 introduces a breaking change to the behavior of `keyof`
that requires us to switch over to using a more narrow system
(StringKeyOf).

Doesn't upgrade to webpack4 yet, as that's a major change.