### PR TITLE
Sort killmails by timestamp before ingesting them

### DIFF
--- a/src/cron/task/syncKillmails.ts
+++ b/src/cron/task/syncKillmails.ts
@@ -10,6 +10,7 @@ import { MemberCorporation } from '../../dao/tables';
 import { inspect } from 'util';
 import { autoTriageLosses } from '../../srp/triage/autoTriageLosses';
 import { pluck } from '../../util/underscore';
+import { ZKillmail } from '../../data-source/zkillboard/ZKillmail';
 
 
 /**
@@ -114,6 +115,7 @@ async function syncLossesWithinRange(
   let newRowCount = 0;
 
   if (mails.length > 0) {
+    mails.sort(sortKillmailsByTimestamp);
     const rows =
         killmailsToRows(mails, corpId, CAPSULE_SHIP_ASSOCIATION_WINDOW);
     newRowCount = await dao.killmail.upsertKillmails(db, rows);
@@ -138,4 +140,10 @@ async function createSrpEntriesForNewLosses(db: Tnex) {
 function getZkillboardQueryUrl(sourceCorporation: number, startTime: number) {
   const sinceArg = formatZKillTimeArgument(moment(startTime));
   return `corporationID/${sourceCorporation}/losses/startTime/${sinceArg}`;
+}
+
+function sortKillmailsByTimestamp(a: ZKillmail, b: ZKillmail) {
+  const ta = moment.utc(a.killmail_time).valueOf();
+  const tb = moment.utc(b.killmail_time).valueOf();
+  return ta - tb;
 }

--- a/src/cron/task/syncKillmails/killmailsToRows.ts
+++ b/src/cron/task/syncKillmails/killmailsToRows.ts
@@ -5,7 +5,6 @@ import { Killmail } from '../../../dao/tables';
 import { TYPE_CAPSULE, TYPE_CAPSULE_GENOLUTION } from '../../../eve/constants/types';
 import { HullCategory, KillmailType } from '../../../dao/enums';
 import { Moment } from 'moment';
-import { inspect } from 'util';
 
 
 /**
@@ -52,7 +51,7 @@ export function killmailsToRows(
     const row = {
       km_id: mail.killmail_id,
       km_character: victimCharacter || null,
-      km_timestamp: moment(mail.killmail_time).valueOf(),
+      km_timestamp: timestamp.valueOf(),
       km_type: KillmailType.LOSS,
       km_hullCategory: getHullCategory(mail),
       km_relatedLoss: associatedId,


### PR DESCRIPTION
zKill returns KMs sorted by ID. This is usually, but not always, the same
ordering as if they were sorted by timestamp. Now we sort by timestamp
before processing.