### PR TITLE
Add state param to reauth login prompt

### DIFF
--- a/src/client/dashboard/ReauthenticationPrompt.vue
+++ b/src/client/dashboard/ReauthenticationPrompt.vue
@@ -7,7 +7,8 @@
   </div>
   <div class="cnt-right">
     <a class="reauth-btn roster-btn"
-        :href="'https://login.eveonline.com/oauth/authorize?' + loginParams"
+        :href="'https://login.eveonline.com/oauth/authorize'
+            + '?state=addCharacter&' + loginParams"
         >Reauthorize</a>
   </div>
 </div>


### PR DESCRIPTION
This was causing logins to fail if users pressed the button.