### PR TITLE
Update ZKillmail interface to more accurately match real world

### DIFF
--- a/src/data-source/zkillboard/ZKillmail.ts
+++ b/src/data-source/zkillboard/ZKillmail.ts
@@ -4,19 +4,7 @@
 export interface ZKillmail {
   killmail_id: number,
   killmail_time: string,
-  victim: {
-    damage_taken: number,
-    ship_type_id: number,
-    character_id?: number,
-    corporation_id: number,
-    alliance_id?: number,
-    items: (DestroyedItem | DroppedItem)[],
-    position: {
-      x: number,
-      y: number,
-      z: number,
-    }
-  },
+  victim: Victim,
   attackers: Attacker[],
   solar_system_id: number,
   zkb: {
@@ -45,37 +33,85 @@ export interface DroppedItem {
   quantity_dropped: number,
 }
 
-export type Attacker = NpcAttacker | PlayerAttacker | StructureAttacker;
+/*
+ * A note about victims and attackers
+ *
+ * Many different entities in EVE can be both victims and attackers -- ships
+ * certainly, but also structures, NPCs, NPCs that work for corporations, NPCs
+ * that are treated like players, and even certain environmental effects like
+ * poisonous clouds. Sometimes common entities like ships and structures are
+ * associated with players; sometimes they aren't.
+ *
+ * Below are a few common patterns, but in general your code must expect that
+ * ANY combination of the optional fields below can occur. Of particular note
+ * is that there is no reliable way to tell the difference between a
+ * player corporation-owned structure and a "corporation NPC" (beyond checking
+ * the corporation ID against a list of known NPC corps).
+ *
+ * Finally, a few oddities. The ship_type_id property is present for most
+ * entities but is sometimes left blank for reasons known only to CCP. If an
+ * attacker dies before their victim does, their ship_type_id is sometimes
+ * reported as a capsule rather than the ship they were flying (or is left
+ * blank). In certain rare cases the ship_type_id will be omitted but
+ * weapon_type_id will be set to the actual ship ID (rather than a weapon).
+ * This is most common on field-applying ships such as HICs.
+ *
+ * Examples:
+ *
+ * Player-owned ship or player-owned structure (e.g. MTU)
+ * {
+ *  character_id,
+ *  corpororation_id,
+ *  alliance_id?,
+ * }
+ *
+ * Corporation-owned structure
+ * {
+ *  corporation_id,
+ *  alliance_id?,
+ * }
+ *
+ * Normal NPC
+ * {
+ *  faction_id,
+ * }
+ *
+ * "Character" NPC (Arithmos Tyrranos)
+ * {
+ *  character_id,
+ *  corporation_id,
+ *  faction_id,
+ * }
+ *
+ * "Corporation" NPC (CONCORD, Faction Police, etc.)
+ * {
+ *  corporation_id,
+ * }
+ */
 
-export interface BaseAttacker {
+export interface Victim {
+  damage_taken: number,
+  ship_type_id: number,
+  character_id?: number,
+  corporation_id?: number,
+  alliance_id?: number,
+  faction_id?: number,
+  items?: (DestroyedItem | DroppedItem)[],
+  position?: {
+    x: number,
+    y: number,
+    z: number,
+  }
+}
+
+export interface Attacker {
   final_blow: boolean,
   damage_done: number,
-  ship_type_id: number | undefined,
   security_status: 0,
-}
-
-export interface NpcAttacker extends BaseAttacker {
-  faction_id: number,
-}
-
-export interface PlayerAttacker extends BaseAttacker {
-  character_id: number,
-  corporation_id: number,
-  alliance_id: number | undefined,
-  weapon_type_id: number,
-}
-
-export interface StructureAttacker extends BaseAttacker {
-  corporation_id: number,
-}
-
-export function isPlayerAttacker(
-    attacker: Attacker): attacker is PlayerAttacker {
-  return (<PlayerAttacker>attacker).character_id != undefined;
-}
-
-export function isStructureAttacker(
-    attacker: Attacker): attacker is StructureAttacker {
-  return (<StructureAttacker>attacker).corporation_id != undefined
-      && (<PlayerAttacker>attacker).character_id == undefined;
+  ship_type_id?: number,
+  weapon_type_id?: number,
+  character_id?: number,
+  corporation_id?: number,
+  alliance_id?: number,
+  faction_id?: number,
 }

--- a/src/route/api/killmail/killmail_GET.ts
+++ b/src/route/api/killmail/killmail_GET.ts
@@ -4,8 +4,7 @@ import { AccountPrivileges } from '../../../route-helper/privileges';
 import { idParam } from '../../../route-helper/paramVerifier';
 import { dao } from '../../../dao';
 import { NotFoundError } from '../../../error/NotFoundError';
-import swagger from '../../../swagger';
-import { ZKillmail, isPlayerAttacker, isStructureAttacker } from '../../../data-source/zkillboard/ZKillmail';
+import { ZKillmail } from '../../../data-source/zkillboard/ZKillmail';
 import { SimpleNumMap, nil } from '../../../util/simpleTypes';
 import { fetchEveNames } from '../../../eve/names';
 
@@ -50,20 +49,18 @@ async function buildNameMap(mail: ZKillmail) {
   unnamedIds.add(mail.victim.alliance_id!);
   unnamedIds.add(mail.victim.ship_type_id);
 
-  for (let item of mail.victim.items) {
-    unnamedIds.add(item.item_type_id);
+  if (mail.victim.items) {
+    for (let item of mail.victim.items) {
+      unnamedIds.add(item.item_type_id);
+    }
   }
   for (let attacker of mail.attackers) {
     unnamedIds.add(attacker.ship_type_id!);
-
-    if (isPlayerAttacker(attacker)) {
-      unnamedIds.add(attacker.character_id);
-      unnamedIds.add(attacker.corporation_id);
-      unnamedIds.add(attacker.alliance_id!);
-      unnamedIds.add(attacker.weapon_type_id);
-    } else if (isStructureAttacker(attacker)) {
-      unnamedIds.add(attacker.corporation_id);
-    }
+    unnamedIds.add(attacker.weapon_type_id);
+    unnamedIds.add(attacker.character_id);
+    unnamedIds.add(attacker.corporation_id);
+    unnamedIds.add(attacker.alliance_id);
+    unnamedIds.add(attacker.faction_id);
   }
   return await fetchEveNames(unnamedIds);
 }

--- a/src/srp/SrpLossJson.ts
+++ b/src/srp/SrpLossJson.ts
@@ -1,5 +1,4 @@
 import { SrpVerdictStatus, SrpVerdictReason } from "../dao/enums";
-import { Nullable } from "../util/simpleTypes";
 
 
 /**
@@ -10,8 +9,8 @@ export interface SrpLossJson {
   killmail: number,
   timestamp: string,
   shipType: number,
-  victim: number | undefined,
-  victimCorp: number,
+  victim?: number,
+  victimCorp?: number,
   executioner: AttackerJson,
   relatedKillmail: {
     id: number | null,
@@ -37,25 +36,12 @@ export interface VerdictOptionJson {
   verdict: SrpVerdictStatus,
 }
 
-export type AttackerJson =
-    PlayerAttackerJson | StructureAttackerJson | NpcAttackerJson;
-
-export interface PlayerAttackerJson {
-  type: 'player',
-  character: number,
-  corporation: number,
-  alliance: number | undefined,
-}
-
-export interface StructureAttackerJson {
-  type: 'structure',
-  ship: number | undefined,
-  corporation: number,
-}
-
-export interface NpcAttackerJson {
-  type: 'npc',
-  ship: number | undefined,
+export interface AttackerJson {
+  ship?: number,
+  character?: number,
+  corporation?: number,
+  alliance?: number,
+  faction?: number,
 }
 
 export type UnifiedSrpLossStatus = SrpVerdictStatus | 'paid';

--- a/src/srp/srpLossToJson.ts
+++ b/src/srp/srpLossToJson.ts
@@ -2,10 +2,9 @@ const moment = require('moment');
 
 import { SrpLossRow } from "../dao/SrpDao";
 import { nil } from "../util/simpleTypes";
-import { ZKillmail, isPlayerAttacker, isStructureAttacker } from "../data-source/zkillboard/ZKillmail";
+import { ZKillmail } from "../data-source/zkillboard/ZKillmail";
 import { findWhere } from "../util/underscore";
-import { SrpVerdictStatus } from "../dao/enums";
-import { SrpLossJson, UnifiedSrpLossStatus, PlayerAttackerJson, NpcAttackerJson, AttackerJson } from "./SrpLossJson";
+import { SrpLossJson, UnifiedSrpLossStatus, AttackerJson } from "./SrpLossJson";
 
 
 /**
@@ -16,7 +15,9 @@ import { SrpLossJson, UnifiedSrpLossStatus, PlayerAttackerJson, NpcAttackerJson,
  * @param ids Will add any IDs that need names into this set.
  */
 export function srpLossToJson(
-    row: SrpLossRow, ids: Set<number | nil>): SrpLossJson {
+    row: SrpLossRow,
+    ids: Set<number | nil>,
+): SrpLossJson {
   const json: SrpLossJson = {
     killmail: row.km_id,
     timestamp: moment.utc(row.km_timestamp).format('YYYY-MM-DD HH:mm'),
@@ -46,37 +47,21 @@ export function srpLossToJson(
 }
 
 function getExecutioner(
-    mail: ZKillmail, ids: Set<number | nil>,
+    mail: ZKillmail,
+    ids: Set<number | nil>,
 ): AttackerJson {
   const executioner = findWhere(mail.attackers, { final_blow: true })!;
-  if (isPlayerAttacker(executioner)) {
-    ids.add(executioner.character_id);
-    ids.add(executioner.corporation_id);
-    if (executioner.alliance_id != null) {
-      ids.add(executioner.alliance_id);
-    }
 
-    return {
-      type: 'player',
-      character: executioner.character_id,
-      corporation: executioner.corporation_id,
-      alliance: executioner.alliance_id,
-    };
-  } else if (isStructureAttacker(executioner)) {
-    ids.add(executioner.ship_type_id)
-    ids.add(executioner.corporation_id);
+  ids.add(executioner.ship_type_id);
+  ids.add(executioner.character_id);
+  ids.add(executioner.corporation_id);
+  ids.add(executioner.alliance_id);
 
-    return {
-      type: 'structure',
-      corporation: executioner.corporation_id,
-      ship: executioner.ship_type_id,
-    }
-  } else {
-    ids.add(executioner.ship_type_id);
-
-    return {
-      type: 'npc',
-      ship: executioner.ship_type_id,
-    };
-  }
+  return {
+    ship: executioner.ship_type_id,
+    character: executioner.character_id,
+    corporation: executioner.corporation_id,
+    alliance: executioner.alliance_id,
+    faction: executioner.faction_id,
+  };
 }

--- a/src/srp/triage/rules.ts
+++ b/src/srp/triage/rules.ts
@@ -540,6 +540,12 @@ function million(value: number) {
 }
 
 function invMatchAll(killmail: ZKillmail, items: number[]) {
+  if (items.length == 0) {
+    return true;
+  }
+  if (killmail.victim.items == undefined) {
+    return false;
+  }
   for (let i = 0; i < items.length; i++) {
     let id = items[i];
     if (findWhere(killmail.victim.items, { item_type_id: id }) == undefined) {
@@ -550,6 +556,9 @@ function invMatchAll(killmail: ZKillmail, items: number[]) {
 }
 
 function invMatchAny(killmail: ZKillmail, items: number[]) {
+  if (killmail.victim.items == undefined) {
+    return undefined;
+  }
   for (let i = 0; i < items.length; i++) {
     let id = items[i];
     if (findWhere(killmail.victim.items, { item_type_id: id }) != undefined) {


### PR DESCRIPTION
Previously we were attempting to distinguish between different kinds of
attackers, but it turns out that this is a fool's errand as the properties
can appear in almost any combination. Better to just treat it as such.

Also marks the "items" section as optional. I've never seen a killmail
without one, but the REST spec says its optional.

Surprisingly, no front-end changes necessary.