### PR TITLE
Autogenerate battle reports in syncKillmails

### DIFF
--- a/schema/011-srp-battles.js
+++ b/schema/011-srp-battles.js
@@ -1,0 +1,24 @@
+
+/**
+ * Creates tables to track killmails clustered into battles.
+ */
+
+exports.up = async function(trx) {
+  await trx.schema.createTable('battle', table => {
+    table.increments('id');
+    table.bigInteger('start').notNullable().index();
+    table.bigInteger('end').notNullable().index();
+    table.jsonb('data').notNullable();
+  });
+
+  await trx.schema.createTable('killmailBattle', table => {
+    table.integer('killmail').primary().references('killmail.id');
+    table.integer('battle')
+        .references('battle.id').onDelete('CASCADE').notNullable().index();
+  });
+}
+
+exports.down = async function(trx) {
+  await trx.schema.dropTable('killmailBattle');
+  await trx.schema.dropTable('battle');
+}

--- a/src/cron/task/syncKillmails.ts
+++ b/src/cron/task/syncKillmails.ts
@@ -11,6 +11,7 @@ import { inspect } from 'util';
 import { autoTriageLosses } from '../../srp/triage/autoTriageLosses';
 import { pluck } from '../../util/underscore';
 import { ZKillmail } from '../../data-source/zkillboard/ZKillmail';
+import { createPendingBattles } from '../../domain/battle/createPendingBattles';
 
 
 /**
@@ -38,6 +39,7 @@ export async function syncKillmails(db: Tnex, job: JobLogger) {
 
   await dao.config.set(db, { 'killmailSyncRanges':  syncedRanges });
   await createSrpEntriesForNewLosses(db);
+  await createPendingBattles(db, job);
 }
 
 async function syncKillmailsForAllCorps(

--- a/src/dao.ts
+++ b/src/dao.ts
@@ -1,5 +1,6 @@
 import AccessTokenDao from './dao/AccessTokenDao';
 import AccountDao from './dao/AccountDao';
+import BattleDao from './dao/BattleDao';
 import CharacterDao from './dao/CharacterDao';
 import CharacterLocationDao from './dao/CharacterLocationDao';
 import CitadelDao from './dao/CitadelDao';
@@ -23,24 +24,25 @@ export class Dao {
   // This way, both, say, the CharacterDao and the AccountDao could call methods
   // on each other without introducing a circular dep.
 
-  public accessToken = new AccessTokenDao(this);
-  public account = new AccountDao(this);
-  public character = new CharacterDao(this);
-  public characterLocation = new CharacterLocationDao(this);
-  public citadel = new CitadelDao(this);
-  public combatStats = new CombatStatsDao(this);
-  public config = new ConfigDao(this);
-  public cron = new CronDao(this);
-  public group = new GroupsDao(this);
-  public killmail = new KillmailDao(this);
-  public log = new LogDao(this);
-  public ownership = new OwnershipDao(this);
-  public roster = new RosterDao(this);
-  public sde = new SdeDao(this);
-  public srp = new SrpDao(this);
-  public skillQueue = new SkillQueueDao(this);
-  public skillsheet = new SkillsheetDao(this);
-  public statistics = new StatisticsDao(this);
+  public readonly accessToken = new AccessTokenDao(this);
+  public readonly account = new AccountDao(this);
+  public readonly battle = new BattleDao(this);
+  public readonly character = new CharacterDao(this);
+  public readonly characterLocation = new CharacterLocationDao(this);
+  public readonly citadel = new CitadelDao(this);
+  public readonly combatStats = new CombatStatsDao(this);
+  public readonly config = new ConfigDao(this);
+  public readonly cron = new CronDao(this);
+  public readonly group = new GroupsDao(this);
+  public readonly killmail = new KillmailDao(this);
+  public readonly log = new LogDao(this);
+  public readonly ownership = new OwnershipDao(this);
+  public readonly roster = new RosterDao(this);
+  public readonly sde = new SdeDao(this);
+  public readonly srp = new SrpDao(this);
+  public readonly skillQueue = new SkillQueueDao(this);
+  public readonly skillsheet = new SkillsheetDao(this);
+  public readonly statistics = new StatisticsDao(this);
 }
 
 export const dao = new Dao();

--- a/src/dao/BattleDao.ts
+++ b/src/dao/BattleDao.ts
@@ -1,0 +1,108 @@
+import { Dao } from '../dao';
+import { Tnex, val, ResultOrder } from '../tnex';
+import { killmail, killmailBattle, battle, Battle, srpVerdict } from './tables';
+import { SrpVerdictStatus } from './enums';
+
+export default class BattleDao {
+  constructor(
+      private _dao: Dao,
+      ) {
+  }
+
+  async getEarliestUngroupedKillmailTimestamp(db: Tnex) {
+    return db
+        .select(killmail)
+        .leftJoin(killmailBattle, 'kmb_killmail', '=', 'km_id')
+        .whereNull('kmb_killmail')
+        .orderBy('km_timestamp', 'asc')
+        .orderBy('km_id', 'asc')
+        .limit(1)
+        .columns(
+            'km_timestamp',
+            )
+        .fetchFirst();
+  }
+
+  getKillmailsWithoutBattlesIterator(db: Tnex, batchSize: number) {
+    return {
+      _prevTimestamp: null as number | null,
+      _previousMails: new Set<number>(),
+
+      async next() {
+        let query = db
+            .select(killmail)
+            .leftJoin(killmailBattle, 'kmb_killmail', '=', 'km_id')
+            .whereNull('kmb_killmail')
+            .orderBy('km_timestamp', 'asc')
+            .orderBy('km_id', 'asc')
+            .columns(
+                'km_timestamp',
+                'km_data',
+                )
+            .limit(batchSize)
+
+        if (this._prevTimestamp != null) {
+          query = query.where('km_timestamp', '>=', val(this._prevTimestamp));
+        }
+        let rows = await query.run();
+        rows = rows.filter(
+            row => !this._previousMails.has(row.km_data.killmail_id));
+
+        if (rows.length > 0) {
+          this._prevTimestamp = rows[rows.length - 1].km_timestamp;
+          this._previousMails.clear();
+          for (let i = rows.length - 1; i >= 0; i--) {
+            let row = rows[i];
+            if (row.km_timestamp != this._prevTimestamp) {
+              break;
+            }
+            this._previousMails.add(row.km_data.killmail_id);
+          }
+        }
+        return rows;
+      }
+    };
+  }
+
+  createBattle(db: Tnex, row: Battle) {
+    return db.insert(battle, row, 'battle_id');
+  }
+
+  deleteBattle(db: Tnex, id: number) {
+    return db
+        .del(battle)
+        .where('battle_id', '=', val(id))
+        .run();
+  }
+
+  updateBattle(db: Tnex, id: number, newVals: Partial<Battle>) {
+    return db
+        .update(battle, newVals)
+        .where('battle_id', '=', val(id))
+        .run();
+  }
+
+  setAssociatedKillmails(db: Tnex, battleId: number, killmails: number[]) {
+    return db.upsertAll(
+        killmailBattle,
+        killmails.map(kmId => ({
+          kmb_killmail: kmId,
+          kmb_battle: battleId,
+        })),
+        'kmb_killmail');
+  }
+
+  getBattlesWithinRange(db: Tnex, start: number, end: number) {
+    return db
+        .select(battle)
+        .where('battle_end', '>=', val(start))
+        .where('battle_start', '<=', val(end))
+        .columns(
+            'battle_id',
+            'battle_start',
+            'battle_end',
+            'battle_data',
+            )
+        .run();
+  }
+}

--- a/src/dao/tables.ts
+++ b/src/dao/tables.ts
@@ -1,6 +1,7 @@
 import { TnexBuilder, nullable, integer, varchar, bigInt, boolean, text, jsonb, strEnum, float4, decimal } from '../tnex';
 import { PrivilegeName, KillmailType, HullCategory, SrpVerdictStatus, SrpVerdictReason } from './enums';
 import { ZKillmail } from '../data-source/zkillboard/ZKillmail';
+import { BattleData } from '../domain/battle/BattleData';
 
 
 export const tables = new TnexBuilder();
@@ -41,6 +42,14 @@ export class AccountLog {
   accountLog_data = nullable(text());
 }
 export const accountLog = tables.register(new AccountLog());
+
+export class Battle {
+  battle_id = integer();
+  battle_start = bigInt();
+  battle_end = bigInt();
+  battle_data = jsonb<BattleData>();
+}
+export const battle = tables.register(new Battle());
 
 export class Character {
   character_id = integer();
@@ -149,24 +158,28 @@ export class Killmail {
   km_id = integer();
   km_timestamp = bigInt();
   km_character = nullable(integer());
-  /** Currently always LOSS. */
   km_type = strEnum<KillmailType>();
   km_hullCategory = strEnum<HullCategory>();
+
   /**
-   * If a ship, the related capsule loss for that character (if any), and
-   * vice-versa.
+   * If a ship, the related capsule loss for that character (if any). If a
+   * capsule, the related ship loss (if any).
    */
   km_relatedLoss = nullable(integer());
-  /**
-   * The corporation whose killboard this loss was fetched from.
-   */
+
+  /** The corporation whose killboard this loss was fetched from. */
   km_sourceCorporation = integer();
-  /**
-   * The full JSON blob received from ZKillboard.
-   */
+
+  /** The full JSON blob received from ZKillboard. */
   km_data = jsonb<ZKillmail>();
 }
 export const killmail = tables.register(new Killmail());
+
+export class KillmailBattle {
+  kmb_killmail = integer();
+  kmb_battle = integer();
+}
+export const killmailBattle = tables.register(new KillmailBattle());
 
 export class MemberCorporation {
   memberCorporation_corporationId = integer();

--- a/src/domain/battle/BatchedObjectReader.ts
+++ b/src/domain/battle/BatchedObjectReader.ts
@@ -1,0 +1,56 @@
+import { Readable } from 'stream';
+import { Select } from '../../tnex/Select';
+
+/**
+ * Given an asynchronous "iterator" that returns an array of objects,
+ * repeatedly "reads" from the iterator until the iterator returns an empty
+ * array.
+ *
+ * Primarily useful for iterating over rows in a database.
+ */
+export class BatchedObjectReader<S> extends Readable {
+
+  private readonly _iterator: StreamIterator<S>;
+
+  private _state: 'dormant' | 'draining' | 'drained' | 'error' = 'dormant';
+
+  constructor(
+      iterator: StreamIterator<S>,
+  ) {
+    super({
+      objectMode: true,
+    });
+    this._iterator = iterator;
+  }
+
+  _read(size: number) {
+    this._performRead()
+    .catch(err => {
+      this._state = 'error';
+      process.nextTick(() => this.emit('error', err));
+    });
+  }
+
+  private async _performRead() {
+    if (this._state != 'dormant') {
+      throw new Error(`Cannot read: state is ${this._state}.`);
+    }
+    this._state = 'draining';
+
+    const objs = await this._iterator.next();
+    for (let obj of objs) {
+      this.push(obj);
+    }
+
+    if (objs.length == 0) {
+      this._state = 'drained';
+      this.push(null);
+    } else {
+      this._state = 'dormant';
+    }
+  }
+}
+
+export interface StreamIterator<S> {
+  next(): Promise<S[]>
+}

--- a/src/domain/battle/BattleCreator.ts
+++ b/src/domain/battle/BattleCreator.ts
@@ -1,0 +1,247 @@
+import moment = require('moment');
+
+import { Transform, TransformCallback } from 'stream';
+import { ZKillmail } from '../../data-source/zkillboard/ZKillmail';
+import { Battle, Killmail } from '../../dao/tables';
+import { Participant } from './BattleData';
+
+
+/**
+ * Transform stream that accepts a stream of killmails and outputs a stream of
+ * "battles".
+ *
+ * Battles are essentially just clusters of related killmails.
+ *
+ */
+export class BattleCreator extends Transform {
+  private readonly _battles = new Set<InternalBattle>();
+  private readonly _assocWindow: number;
+
+  constructor(initialBattles: Battle[], maxAssociationWindow: number) {
+    super({
+      objectMode: true,
+    });
+    this._assocWindow = maxAssociationWindow;
+
+    for (let battleRow of initialBattles) {
+      this._battles.add(battleRowToInternalBattle(battleRow));
+    }
+  }
+
+  public _transform(chunk: any, encoding: string, callback: TransformCallback) {
+    try {
+      this._transformChunk(chunk);
+      callback();
+    } catch (err) {
+      this.emit('error', err);
+    }
+  }
+
+  private _transformChunk(chunk: Pick<Killmail, 'km_timestamp' | 'km_data'>) {
+    const killmail = chunk.km_data;
+
+    this._flushBattlesOutsideOfWindow(chunk.km_timestamp);
+
+    const participants = extractParticipants(killmail);
+    const involvedBattles: InternalBattle[] = [];
+    for (let battle of this._battles) {
+      for (let participant of participants) {
+        if (isMatchableParticipant(participant)
+            && battle.participants.has(participant.id)) {
+          involvedBattles.push(battle);
+          break;
+        }
+      }
+    }
+    const finalBattle = this._fuseBattles(involvedBattles);
+
+    if (!finalBattle.killmails.has(killmail.killmail_id)) {
+      finalBattle.start = Math.min(finalBattle.start, chunk.km_timestamp);
+      finalBattle.end = Math.max(finalBattle.end, chunk.km_timestamp);
+      finalBattle.killmails.add(killmail.killmail_id);
+      finalBattle.locations.add(killmail.solar_system_id);
+      for (let participant of participants) {
+        addParticipant(finalBattle, participant);
+      }
+    }
+  }
+
+  public _flush(callback: TransformCallback) {
+    try {
+      this._flushRemainingBattles();
+      callback();
+    } catch (err) {
+      this.emit('error', err);
+    }
+  }
+
+  private _flushRemainingBattles() {
+    for (let battle of this._battles) {
+      this._flushBattle(battle);
+    }
+  }
+
+  private _flushBattlesOutsideOfWindow(mostRecentKmTimestamp: number) {
+    const doneBattles: InternalBattle[] = [];
+    for (let battle of this._battles) {
+      if (mostRecentKmTimestamp - battle.start > this._assocWindow) {
+        doneBattles.push(battle);
+      }
+    }
+    for (let doneBattle of doneBattles) {
+      this._flushBattle(doneBattle);
+    }
+  }
+
+  private _fuseBattles(battles: InternalBattle[]) {
+    let outBattle: InternalBattle;
+
+    if (battles.length == 0) {
+      outBattle = {
+        id: null,
+        start: Number.MAX_SAFE_INTEGER,
+        end: Number.MIN_SAFE_INTEGER,
+        killmails: new Set<number>(),
+        locations: new Set<number>(),
+        participants: new Map<string, Participant>(),
+      };
+    } else if (battles.length == 1) {
+      outBattle = battles[0];
+    } else {
+      outBattle = battles[0];
+      for (let i = 1; i < battles.length; i++) {
+        const subBattle = battles[i];
+        joinBattles(outBattle, subBattle);
+        this._discardBattle(subBattle);
+      }
+    }
+
+    this._battles.add(outBattle);
+    return outBattle;
+  }
+
+  private _flushBattle(battle: InternalBattle) {
+    this._battles.delete(battle);
+    this.push({
+      type: 'created',
+      battle: battle,
+    });
+  }
+
+  private _discardBattle(battle: InternalBattle) {
+    this._battles.delete(battle);
+    if (battle.id != null) {
+      this.push({
+        type: 'deleted',
+        battleId: battle.id,
+      });
+    }
+  }
+}
+
+function joinBattles(left: InternalBattle, right: InternalBattle) {
+  left.start = Math.min(left.start, right.start);
+  left.end = Math.max(left.end, right.end);
+  for (let killmail of right.killmails) {
+    left.killmails.add(killmail);
+  }
+  for (let location of right.locations) {
+    left.locations.add(location);
+  }
+  for (let participant of right.participants.values()) {
+    addParticipant(left, participant);
+  }
+}
+
+function addParticipant(battle: InternalBattle, participant: Participant) {
+  let existing = battle.participants.get(participant.id);
+  if (existing == undefined) {
+    battle.participants.set(participant.id, participant);
+  } else {
+    if (existing.loss == null && participant.loss != null) {
+      existing.loss = participant.loss;
+    }
+  }
+}
+
+function extractParticipants(killmail: ZKillmail) {
+  const participants: Participant[] = [];
+
+  const victim = buildParticipant(killmail.victim);
+  victim.loss = {
+    killmailId: killmail.killmail_id,
+    value: killmail.zkb.totalValue,
+  };
+
+  participants.push(victim);
+  for (let attacker of killmail.attackers) {
+    participants.push(buildParticipant(attacker));
+  }
+
+  return participants;
+}
+
+function buildParticipant(entity: KillmailEntity): Participant {
+  const id = `${entity.ship_type_id},`
+      + `${entity.character_id || entity.corporation_id || entity.faction_id}`;
+  return {
+    id: id,
+    shipId: entity.ship_type_id,
+    characterId: entity.character_id,
+    corporationId: entity.corporation_id,
+    allianceId: entity.alliance_id,
+    factionId: entity.faction_id,
+    loss: null,
+  }
+}
+
+function isMatchableParticipant(p: Participant) {
+  // Heuristic to detect whether the participant is a player
+  return p.characterId != undefined && p.factionId == undefined;
+}
+
+interface KillmailEntity {
+  ship_type_id?: number,
+  character_id?: number,
+  corporation_id?: number,
+  alliance_id?: number,
+  faction_id?: number,
+}
+
+function battleRowToInternalBattle(row: Battle): InternalBattle {
+  const battle: InternalBattle = {
+    id: row.battle_id,
+    start: row.battle_start,
+    end: row.battle_end,
+    killmails: new Set<number>(row.battle_data.killmails),
+    locations: new Set<number>(row.battle_data.locations),
+    participants: new Map<string, Participant>(),
+  };
+
+  for (let participant of row.battle_data.participants) {
+    battle.participants.set(participant.id, participant);
+  }
+
+  return battle;
+}
+
+export interface InternalBattle {
+  id: number | null,
+  start: number,
+  end: number,
+  killmails: Set<number>,
+  locations: Set<number>,
+  participants: Map<string, Participant>,
+}
+
+export type BattleResult = CreatedBattle | DeletedBattle;
+
+export interface CreatedBattle {
+  type: 'created',
+  battle: InternalBattle,
+}
+
+export interface DeletedBattle {
+  type: 'deleted',
+  battleId: number,
+}

--- a/src/domain/battle/BattleData.ts
+++ b/src/domain/battle/BattleData.ts
@@ -1,0 +1,26 @@
+
+/**
+ * The "data" column of the battles table.
+ *
+ * Contains everything you need to know about a battle (besides its ID).
+ */
+export interface BattleData {
+  start: number,
+  end: number,
+  locations: number[],
+  killmails: number[],
+  participants: Participant[]
+}
+
+export interface Participant {
+  id: string,
+  shipId?: number,
+  characterId?: number,
+  corporationId?: number,
+  allianceId?: number,
+  factionId?: number,
+  loss: {
+    killmailId: number,
+    value: number,
+  } | null,
+}

--- a/src/domain/battle/BattleWriter.ts
+++ b/src/domain/battle/BattleWriter.ts
@@ -1,0 +1,63 @@
+import { Writable } from 'stream';
+import { BattleResult } from './BattleCreator';
+import { Tnex, DEFAULT_NUM } from '../../tnex';
+import { dao } from '../../dao';
+import { BattleData } from './BattleData';
+
+
+/**
+ * Writes the output of BattleCreator to the database.
+ */
+export class BattleWriter extends Writable {
+  private readonly _db: Tnex;
+
+  constructor(db: Tnex) {
+    super({
+      objectMode: true,
+    });
+    this._db = db;
+  }
+
+  _write(chunk: any, encoding: string, callback: (err?: Error) => void) {
+    this._writeBattle(chunk as BattleResult, callback)
+    .catch(err => {
+      this.emit('error', err);
+    });
+  }
+
+  private async _writeBattle(
+      result: BattleResult,
+      callback: (err?: Error) => void,
+  ) {
+    if (result.type == 'deleted') {
+      await dao.battle.deleteBattle(this._db, result.battleId);
+    } else {
+      let battle = result.battle;
+      let battleId = battle.id;
+      const data: BattleData = {
+        start: battle.start,
+        end: battle.end,
+        locations: Array.from(battle.locations),
+        killmails: Array.from(battle.killmails),
+        participants: Array.from(battle.participants.values()),
+      };
+      if (battleId == null) {
+        battleId = await dao.battle.createBattle(this._db, {
+          battle_id: DEFAULT_NUM,
+          battle_start: battle.start,
+          battle_end: battle.end,
+          battle_data: data,
+        });
+      } else {
+        await dao.battle.updateBattle(this._db, battleId, {
+          battle_start: battle.start,
+          battle_end: battle.end,
+          battle_data: data,
+        })
+      }
+      await dao.battle.setAssociatedKillmails(
+          this._db, battleId, data.killmails);
+    }
+    callback();
+  }
+}

--- a/src/domain/battle/createPendingBattles.ts
+++ b/src/domain/battle/createPendingBattles.ts
@@ -1,0 +1,53 @@
+import moment = require('moment');
+
+import { Tnex } from '../../tnex';
+import { dao } from '../../dao';
+import { BatchedObjectReader } from './BatchedObjectReader';
+import { BattleCreator } from './BattleCreator';
+import { BattleWriter } from './BattleWriter';
+import { pipeline } from 'stream';
+import { promisify } from 'util';
+import { battle } from '../../dao/tables';
+import { Logger } from '../../logs/Logger';
+
+
+/**
+ * Iterates through any killmails that aren't associated with battle reports
+ * and clusters them into battle reports.
+ *
+ * Pre-existing battles close to the first killmail may be modified and/or
+ * merged with incoming killmails. However, this is only true of battles near
+ * the first new killmail. If there are pre-existing battles later on, they
+ * won't be touched. In general, this is a rare occurrence that can only be
+ * caused by modifying the killmail sync bounds to be deeper into the past.
+ * It may result in some battles on the boundary of the update not being
+ * properly merged, but it's not a huge deal.
+ *
+ * Holds a transactional lock on the battles during the entire process.
+ */
+export async function createPendingBattles(db: Tnex, logger: Logger) {
+  return db.asyncTransaction(async db => {
+    await db.acquireTransactionalLock(battle, -1);
+
+    const row = await dao.battle.getEarliestUngroupedKillmailTimestamp(db);
+    if (row == null) {
+      logger.info(`No rows to battle-cluster.`)
+      return;
+    }
+
+    const initialBattles =
+        await dao.battle.getBattlesWithinRange(db,
+            row.km_timestamp - WINDOW,
+            row.km_timestamp + moment.duration(1, 'hour').asMilliseconds());
+
+    const iterator = dao.battle.getKillmailsWithoutBattlesIterator(db, 300);
+    const reader = new BatchedObjectReader(iterator);
+    const creator = new BattleCreator(initialBattles, WINDOW);
+    const writer = new BattleWriter(db);
+
+    await pipelineAsync(reader, creator, writer);
+  });
+}
+
+const WINDOW = moment.duration(20, 'minutes').asMilliseconds();
+const pipelineAsync = promisify(pipeline);


### PR DESCRIPTION
Adds an extra step to syncKillmails that generates battle reports.

Battle reports use a relatively simple clustering algorithm. The clusterer
defines a sliding temporal window of 20 minutes. If any of the participants
of a killmail also appear in a existing battle in the window, add that
killmail to the battle. Otherwise create a new battle. If a killmail would
be added to more than one battle, first merge the battles.

Uses a stream pipeline to process killmails. In retrospect, streams are kind
of awful, especially in Typescript. But the backpressure management is
nice in this application, as it allows the system to chew through
an arbitrary number of killmails while using a relatively constant amount
of memory.