### PR TITLE
Add front-end support for battles

### DIFF
--- a/src/client/home.js
+++ b/src/client/home.js
@@ -14,7 +14,7 @@ import Dev from './dev/Dev.vue';
 
 import Srp from './srp/Srp.vue';
 import SrpDashboard from './srp/SrpDashboard.vue';
-import LossHistory from './srp/LossHistory.vue';
+import CombatHistory from './srp/CombatHistory.vue';
 import PaymentHistory from './srp/PaymentHistory.vue';
 import PaymentTriage from './srp/PaymentTriage.vue';
 import PaymentDetail from './srp/PaymentDetail.vue';
@@ -46,8 +46,9 @@ const routes = [
         component: SrpDashboard,
       },
       {
-        path: 'losses',
-        component: LossHistory,
+        path: 'history',
+        component: CombatHistory,
+        props: { triageMode: false },
       },
       {
         path: 'payments',
@@ -55,7 +56,7 @@ const routes = [
       },
       {
         path: 'triage',
-        component: LossHistory,
+        component: CombatHistory,
         props: { triageMode: true },
       },
       {

--- a/src/client/shared/ajaxer.js
+++ b/src/client/shared/ajaxer.js
@@ -142,6 +142,15 @@ export default {
     return axios.get('/api/srp/approvedLiability');
   },
 
+  getBattles(filter, includeSrp) {
+    return axios.get('/api/srp/battle', {
+      params: {
+        filter: filter != undefined ? JSON.stringify(filter) : undefined,
+        includeSrp: includeSrp,
+      },
+    });
+  },
+
   getRecentSrpLosses(filter) {
     return axios.get('/api/srp/loss', {
       params: filter

--- a/src/client/srp/CombatHistory.vue
+++ b/src/client/srp/CombatHistory.vue
@@ -1,0 +1,87 @@
+<!--
+
+Displays a list of recent combat activity in the corp
+
+Contains either BattleHistory (default) or LossHistory, controllable via a
+dropdown.
+
+If in triage mode, results are ordered oldest to newest and triage options are
+shown. If not, results are ordered newest to oldest.
+
+-->
+
+<template>
+<div class="_approve">
+  <div class="mode-cnt">
+    Show
+    <select class="mode-select" v-model="mode">
+      <option value="battles">Battle reports</option>
+      <option value="losses">Losses</option>>
+    </select>
+  </div>
+
+  <battle-history
+      v-if="mode=='battles'"
+      :identity="identity"
+      :triage-mode="triageMode"
+      >
+  </battle-history>
+
+  <loss-history
+      v-if="mode=='losses'"
+      :identity="identity"
+      :triage-mode="triageMode"
+      >
+  </loss-history>
+</div>
+</template>
+
+<script>
+import Vue from 'vue';
+
+import LossHistory from './LossHistory.vue';
+import BattleHistory from './battles/BattleHistory.vue';
+
+export default Vue.extend({
+  components: {
+    BattleHistory,
+    LossHistory,
+  },
+
+  props: {
+    identity: { type: Object, required: true, },
+    triageMode: { type: Boolean, required: true, },
+  },
+
+  data() {
+    return {
+      mode: 'battles',
+    };
+  }
+});
+</script>
+
+<style scoped>
+.mode-cnt {
+  color: #A7A29C;
+  font-size: 14px;
+  margin-bottom: 30px;
+}
+
+.mode-select {
+  width: 150px;
+  height: 35px;
+  background: #161616;
+  border: 1px solid #2D2D2D;
+  color: #CDCDCD;
+  font-size: 14px;
+  font-family: unset;
+  border-radius: 0;
+  padding-left: 11px;
+}
+
+.mode-select:focus {
+  outline: none;
+  border-color: #444;
+}
+</style>

--- a/src/client/srp/Srp.vue
+++ b/src/client/srp/Srp.vue
@@ -16,10 +16,10 @@ Root container for the SRP UI.
       Dashboard
     </router-link>
     <router-link
-        to="/srp/losses"
+        to="/srp/history"
         class="nav-link"
         >
-      Losses
+      Activity
     </router-link>
     <router-link
         to="/srp/payments"

--- a/src/client/srp/battles/BattleHistory.vue
+++ b/src/client/srp/battles/BattleHistory.vue
@@ -1,0 +1,144 @@
+<!--
+
+Displays a list of battle reports
+
+Battle reports are instances of BattleRow.
+
+-->
+
+<template>
+<div class="_battle-history">
+
+  <template v-if="battles != null">
+    <battle-row
+        v-for="battle in battles"
+        :key="battle.id"
+        :battle="battle"
+        :has-edit-priv="identity.access['srp'] == 2"
+        :start-in-edit-mode="true"
+        >
+    </battle-row>
+    <div v-if="battles.length == 0" class="no-results">No results</div>
+  </template>
+
+  <div
+      v-if="suspectMoreToFetch"
+      class="more-cnt"
+      >
+    <more-button
+        :promise="fetchPromise"
+        :hide-button="battles == null"
+        @fetch-requested="fetchNextResults"
+        >
+    </more-button>
+  </div>
+</div>
+</template>
+
+<script>
+import _ from 'underscore';
+import Vue from 'vue';
+import BattleRow from './BattleRow.vue';
+import MoreButton from '../MoreButton.vue';
+
+import ajaxer from '../../shared/ajaxer';
+import { NameCacheMixin } from '../../shared/nameCache';
+
+
+export default Vue.extend({
+  components: {
+    BattleRow,
+    MoreButton,
+  },
+
+  props: {
+    identity: { type: Object, required: true, },
+    triageMode: { type: Boolean, required: false, default: false, },
+  },
+
+  data() {
+    return {
+      battles: null,
+      fetchPromise: null,
+      suspectMoreToFetch: true,
+    };
+  },
+
+  computed: {
+  },
+
+  mounted() {
+    this.reset();
+  },
+
+  watch: {
+    triageMode(value) {
+      this.reset();
+    },
+  },
+
+  methods: Object.assign({
+    reset() {
+      this.battles = null;
+      this.fetchPromise = null;
+      this.suspectMoreToFetch = true;
+      this.fetchNextResults();
+    },
+
+    fetchNextResults() {
+      const sentinelId = this.battles != null && this.battles.length > 0
+          ? this.battles[this.battles.length - 1].id : null;
+      const resultOrder = this.triageMode ? 'asc' : 'desc';
+
+      this.fetchPromise = ajaxer.getBattles(
+        {
+          untriaged: this.triageMode,
+          orderBy: [{ key: 'battle_id', order: resultOrder }],
+          limit: RESULTS_PER_FETCH,
+          bound: sentinelId == null ? undefined : {
+            col: 'battle_id',
+            cmp: resultOrder == 'asc' ? '>' : '<',
+            value: sentinelId,
+          },
+        },
+        true);
+
+      this.fetchPromise.then(response => {
+        this.addNames(response.data.names);
+        if (this.battles == null) {
+          this.battles = [];
+        }
+        for (let battle of response.data.battles) {
+          this.battles.push(battle);
+        }
+        this.suspectMoreToFetch =
+            response.data.battles.length == RESULTS_PER_FETCH;
+      });
+    },
+  }, NameCacheMixin),
+});
+
+const RESULTS_PER_FETCH = 30;
+</script>
+
+<style scoped>
+._battle-history {
+  margin-bottom: 500px;
+}
+
+.no-results {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 70px;
+
+  color: #A7A29C;
+  font-size: 14px;
+  font-style: italic;
+}
+
+.more-cnt {
+  margin-top: 20px;
+  text-align: center;
+}
+</style>

--- a/src/client/srp/battles/BattleRow.vue
+++ b/src/client/srp/battles/BattleRow.vue
@@ -1,0 +1,258 @@
+<!--
+
+Displays a single battle report
+
+May also contain triage UI if triageMode is enabled.
+
+-->
+
+<template>
+<div class="_battle-row">
+
+  <div class="header">
+    <div class="start-time">{{ battle.startLabel }}</div>
+    <div class="locations">{{ battle.locations.map(name).join(', ') }}</div>
+    <div class="total-losses">{{ formatIskValue(battleLosses) }}</div>
+  </div>
+
+  <div class="team-row"
+      v-for="team in battle.teams"
+      :key="team.corporationId"
+      >
+    <srp-triplet
+        v-if="team.corporationId != 0"
+        class="team-triplet"
+        :icon-id="team.corporationId"
+        :icon-type="'Corporation'"
+        :top-line="name(team.corporationId)"
+        :bottom-line="team.allianceId && name(team.allianceId)"
+        :default-href="zkillHref(team.corporationId, 'corporation')"
+        :bot-href="team.allianceId && zkillHref(team.allianceId, 'alliance')"
+        >
+    </srp-triplet>
+    <div v-else class="empty-team">Unaffiliated</div>
+    <div class="participant-cnt">
+      <div class="participant"
+          v-for="member in team.members"
+          :key="member.id"
+          >
+        <tooltip gravity="center top">
+          <a
+              class="killmail-link"
+              :href="member.loss ?
+                  zkillHref(member.loss.killmailId, 'kill') : undefined"
+              target="_blank"
+              >
+            <eve-image
+                class="ship-image"
+                :id="member.shipId"
+                :size="36"
+                type="Type"
+                >
+            </eve-image>
+          </a>
+          <srp-triplet
+              class="hover-triplet"
+              slot="message"
+              :icon-id="member.characterId || member.shipId"
+              :icon-type="member.characterId ? 'Character' : 'Type'"
+              :top-line="name(member.characterId || member.shipId)"
+              :bottom-line="name(member.shipId)"
+              >
+          </srp-triplet>
+        </tooltip>
+        <div class="death-scrim" v-if="member.loss"></div>
+      </div>
+    </div>
+    <div class="loss-count">{{ formatIskValue(team.totalLosses) }}</div>
+  </div>
+  <div class="srp-cnt" v-if="battle.srps.length > 0">
+    <div
+        class="srp"
+        v-for="srp in battle.srps"
+        :key="srp.killmail"
+        >
+      <srp-triplet
+          class="srp-triplet"
+          :icon-id="srp.shipType"
+          :icon-type="'Type'"
+          :top-line="name(srp.victim)"
+          :bottom-line="name(srp.shipType)"
+          :default-href="zkillHref(srp.killmail, 'kill')"
+          >
+      </srp-triplet>
+      <srp-status
+          :srp="srp"
+          :has-edit-priv="hasEditPriv"
+          :start-in-edit-mode="startInEditMode"
+          >
+      </srp-status>
+    </div>
+  </div>
+</div>
+</template>
+
+<script>
+import Vue from 'vue';
+import EveImage from '../../shared/EveImage.vue';
+import SrpTriplet from '../SrpTriplet.vue';
+import SrpStatus from '../SrpStatus.vue';
+import Tooltip from '../../shared/Tooltip.vue';
+import { NameCacheMixin } from '../../shared/nameCache';
+import { formatNumber } from '../../shared/numberFormat';
+
+
+export default Vue.extend({
+  components: {
+    EveImage,
+    SrpStatus,
+    SrpTriplet,
+    Tooltip,
+  },
+
+  props: {
+    battle: { type: Object, required: true, },
+    hasEditPriv: { type: Boolean, required: true, },
+    startInEditMode: { type: Boolean, required: true, },
+  },
+
+  data() {
+    return {
+      status: 'inactive',   // inactive | active | error
+    };
+  },
+
+  computed: {
+    battleLosses() {
+      let sum = 0;
+      for (let team of this.battle.teams) {
+        sum += team.totalLosses;
+      }
+      return sum;
+    },
+  },
+
+  methods: Object.assign({
+    zkillHref(id, type) {
+      if (id == undefined) {
+        return undefined;
+      } else {
+        return `https://zkillboard.com/${type}/${id}/`;
+      }
+    },
+
+    formatIskValue(value) {
+      return `${formatNumber(value)} ISK`;
+    },
+  }, NameCacheMixin),
+});
+</script>
+
+<style scoped>
+._battle-row {
+  width: 901px;
+  font-size: 14px;
+  margin-bottom: 60px;
+}
+
+.header {
+  display: flex;
+  border-bottom: 1px solid #2C2C2C;
+  padding-bottom: 5px;
+}
+
+.start-time {
+  color: #CDCDCD;
+}
+
+.locations {
+  flex: 1;
+  text-align: center;
+  color: #A7A29C;
+}
+
+.total-losses {
+  color: #A7A29C;
+}
+
+.team-row {
+  display: flex;
+  align-items: center;
+  margin-top: 13px;
+}
+
+.team-triplet, .empty-team {
+  width: 230px;
+  margin-right: 20px;
+}
+
+.empty-team {
+  padding-left: 58px;
+  box-sizing: border-box;
+}
+
+.participant-cnt {
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+}
+
+.participant {
+  position: relative;
+  margin-right: 4px;
+  margin-bottom: 4px;
+}
+
+.hover-triplet {
+  width: 300px;
+}
+
+.killmail-link {
+  display: inline-block;
+}
+
+.death-scrim {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 0, 0, 0.4);
+  pointer-events: none;
+}
+
+.ship-image {
+  vertical-align: middle;
+}
+
+.loss-count {
+  width: 100px;
+  text-align: right;
+  color: #A7A29C;
+}
+
+
+.srp-cnt {
+  width: 665px;
+  margin-left: 236px;
+  margin-top: 10px;
+}
+
+.srp {
+  display: flex;
+  height: 76px;
+
+  align-items: center;
+  padding: 0 14px;
+  background-color: #191919;
+}
+
+.srp + .srp {
+  border-top: 1px solid #202020;
+}
+
+.srp-triplet {
+  flex: 1 1 0;
+  margin-right: 4px;
+}
+</style>


### PR DESCRIPTION
Creates BattleRow, a representation of a battle report. BattleHistory
contains BattleRows and is the equivalent of LossHistory.

Wraps LossHistory/BattleHistory in CombatHistory and presents a dropdown
for selecting which "mode" the user wants to use. Changes
/srp/history and /srp/triage to use CombatHistory.