### PR TITLE
Add generically-typed versions of Node streams

### DIFF
--- a/src/domain/battle/BattleCreator.ts
+++ b/src/domain/battle/BattleCreator.ts
@@ -1,9 +1,7 @@
-import moment = require('moment');
-
-import { Transform, TransformCallback } from 'stream';
 import { ZKillmail } from '../../data-source/zkillboard/ZKillmail';
 import { Battle, Killmail } from '../../db/tables';
 import { Participant } from './BattleData';
+import { Transform, TransformCallback } from '../../util/stream/Transform';
 
 
 /**
@@ -13,7 +11,7 @@ import { Participant } from './BattleData';
  * Battles are essentially just clusters of related killmails.
  *
  */
-export class BattleCreator extends Transform {
+export class BattleCreator extends Transform<Killmail, BattleResult> {
   private readonly _battles = new Set<InternalBattle>();
   private readonly _assocWindow: number;
 
@@ -28,7 +26,11 @@ export class BattleCreator extends Transform {
     }
   }
 
-  public _transform(chunk: any, encoding: string, callback: TransformCallback) {
+  public _transform(
+      chunk: any,
+      encoding: string,
+      callback: TransformCallback<BattleResult>,
+  ) {
     try {
       this._transformChunk(chunk);
       callback();
@@ -66,7 +68,7 @@ export class BattleCreator extends Transform {
     }
   }
 
-  public _flush(callback: TransformCallback) {
+  public _flush(callback: TransformCallback<BattleResult>) {
     try {
       this._flushRemainingBattles();
       callback();

--- a/src/domain/battle/BattleWriter.ts
+++ b/src/domain/battle/BattleWriter.ts
@@ -1,14 +1,15 @@
-import { Writable } from 'stream';
 import { BattleResult } from './BattleCreator';
 import { Tnex, DEFAULT_NUM } from '../../db/tnex';
 import { dao } from '../../db/dao';
 import { BattleData } from './BattleData';
+import { Writable } from '../../util/stream/Writable';
+import { BasicCallback } from '../../util/stream/core';
 
 
 /**
  * Writes the output of BattleCreator to the database.
  */
-export class BattleWriter extends Writable {
+export class BattleWriter extends Writable<BattleResult> {
   private readonly _db: Tnex;
 
   constructor(db: Tnex) {
@@ -18,8 +19,8 @@ export class BattleWriter extends Writable {
     this._db = db;
   }
 
-  _write(chunk: any, encoding: string, callback: (err?: Error) => void) {
-    this._writeBattle(chunk as BattleResult, callback)
+  _write(chunk: BattleResult, encoding: string, callback: BasicCallback) {
+    this._writeBattle(chunk, callback)
     .catch(err => {
       this.emit('error', err);
     });

--- a/src/util/simpleTypes.ts
+++ b/src/util/simpleTypes.ts
@@ -32,3 +32,12 @@ export type KeysOfType<T, PropType> = {
 
 /** Given a type T, filters out all properties whose type is not PropType. */
 export type FilterProps<T, PropType> = Pick<T, KeysOfType<T, PropType>>;
+
+/**
+ * Type equivalent of Object.assign. Combines S and D into a single type, but
+ * any properties with the same name are wholly replaced by D's definitions.
+ */
+export type Overwrite<S, D> = Pick<S, Exclude<keyof S, keyof D>> & D;
+
+/** Removes all properties of S whose keys are assignable to D. */
+export type Omit<S, D> = Pick<S, Exclude<keyof S, D>>;

--- a/src/util/stream/BatchedObjectReadable.ts
+++ b/src/util/stream/BatchedObjectReadable.ts
@@ -1,14 +1,13 @@
-import { Readable } from 'stream';
-import { Select } from '../../db/tnex/Select';
+import { Readable } from './Readable';
 
 /**
- * Given an asynchronous "iterator" that returns an array of objects,
+ * Given an asynchronous 'iterator' that returns an array of objects,
  * repeatedly "reads" from the iterator until the iterator returns an empty
  * array.
  *
  * Primarily useful for iterating over rows in a database.
  */
-export class BatchedObjectReader<S> extends Readable {
+export class BatchedObjectReadable<S> extends Readable<S> {
 
   private readonly _iterator: StreamIterator<S>;
 

--- a/src/util/stream/Duplex.d.ts
+++ b/src/util/stream/Duplex.d.ts
@@ -1,0 +1,145 @@
+import { Writable, WritableOptions } from './Writable';
+import { WriteStream } from './Writable';
+import { ReadStream, Readable, ReadableOptions } from './Readable';
+import { BasicCallback } from './core';
+import { Delete } from '../simpleTypes';
+
+export interface Duplex<In, Out> extends ReadWriteStream<In, Out> {}
+export class Duplex<In, Out> {
+  constructor(opts?: DuplexOptions<Duplex<In, Out>, In, Out>);
+
+  _read?(size: number): void;
+  _destroy?(error: Error | null, callback: BasicCallback): void;
+
+  _write(chunk: Out, encoding: string, callback: BasicCallback): void;
+  _writev?(
+      chunks: Array<{ chunk: Out, encoding: string }>,
+      callback: BasicCallback,
+      ): void;
+  _final(callback: BasicCallback): void;
+}
+
+export interface ReadWriteStream<In, Out> {
+  writable: boolean;
+  readonly writableHighWaterMark: number;
+  readonly writableLength: number;
+  write(chunk: In, cb?: (error: Error | null | undefined) => void): boolean;
+  write(chunk: In, encoding?: string, cb?: (error: Error | null | undefined) => void): boolean;
+  setDefaultEncoding(encoding: string): this;
+  end(cb?: () => void): void;
+  end(chunk: In, cb?: () => void): void;
+  end(chunk: In, encoding?: string, cb?: () => void): void;
+  cork(): void;
+  uncork(): void;
+  destroy(error?: Error): void;
+
+  readable: boolean;
+  readonly readableHighWaterMark: number;
+  readonly readableLength: number;
+  read(size?: number): Out;
+  setEncoding(encoding: string): this;
+  pause(): this;
+  resume(): this;
+  isPaused(): boolean;
+  unpipe<T extends NodeJS.WritableStream>(destination?: T): this;
+  unshift(chunk: Out): void;
+  wrap(oldStream: NodeJS.ReadableStream): this;
+  push(chunk: Out | null, encoding?: string): boolean;
+
+  /**
+   * Event emitter
+   * The defined events on documents including:
+   * 1. close (both)
+   * 2. error (both)
+   * 3. drain (writable)
+   * 4. finish (writable)
+   * 5. pipe (writable)
+   * 6. unpipe (writable)
+   * 7. data (readable)
+   * 8. readable (readable)
+   * 9. end (readable)
+   */
+  addListener(event: 'close', listener: () => void): this;
+  addListener(event: 'error', listener: (err: Error) => void): this;
+  addListener(event: 'drain', listener: () => void): this;
+  addListener(event: 'finish', listener: () => void): this;
+  addListener(event: 'pipe', listener: (src: ReadStream<In>) => void): this;
+  addListener(event: 'unpipe', listener: (src: ReadStream<In>) => void): this;
+  addListener(event: 'data', listener: (chunk: Out) => void): this;
+  addListener(event: 'readable', listener: () => void): this;
+  addListener(event: 'end', listener: () => void): this;
+  addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  emit(event: 'close'): boolean;
+  emit(event: 'error', err: Error): boolean;
+  emit(event: 'drain'): boolean;
+  emit(event: 'finish'): boolean;
+  emit(event: 'pipe', src: ReadStream<In>): boolean;
+  emit(event: 'unpipe', src: ReadStream<In>): boolean;
+  emit(event: 'data', chunk: Out): boolean;
+  emit(event: 'end'): boolean;
+  emit(event: 'readable'): boolean;
+  emit(event: string | symbol, ...args: any[]): boolean;
+
+  on(event: 'close', listener: () => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'drain', listener: () => void): this;
+  on(event: 'finish', listener: () => void): this;
+  on(event: 'pipe', listener: (src: ReadStream<In>) => void): this;
+  on(event: 'unpipe', listener: (src: ReadStream<In>) => void): this;
+  on(event: 'data', listener: (chunk: Out) => void): this;
+  on(event: 'end', listener: () => void): this;
+  on(event: 'readable', listener: () => void): this;
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  once(event: 'close', listener: () => void): this;
+  once(event: 'error', listener: (err: Error) => void): this;
+  once(event: 'drain', listener: () => void): this;
+  once(event: 'finish', listener: () => void): this;
+  once(event: 'pipe', listener: (src: ReadStream<In>) => void): this;
+  once(event: 'unpipe', listener: (src: ReadStream<In>) => void): this;
+  once(event: 'data', listener: (chunk: Out) => void): this;
+  once(event: 'end', listener: () => void): this;
+  once(event: 'readable', listener: () => void): this;
+  once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  prependListener(event: 'close', listener: () => void): this;
+  prependListener(event: 'error', listener: (err: Error) => void): this;
+  prependListener(event: 'drain', listener: () => void): this;
+  prependListener(event: 'finish', listener: () => void): this;
+  prependListener(event: 'pipe', listener: (src: ReadStream<In>) => void): this;
+  prependListener(event: 'unpipe', listener: (src: ReadStream<In>) => void): this;
+  prependListener(event: 'data', listener: (chunk: Out) => void): this;
+  prependListener(event: 'end', listener: () => void): this;
+  prependListener(event: 'readable', listener: () => void): this;
+  prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  prependOnceListener(event: 'close', listener: () => void): this;
+  prependOnceListener(event: 'error', listener: (err: Error) => void): this;
+  prependOnceListener(event: 'drain', listener: () => void): this;
+  prependOnceListener(event: 'finish', listener: () => void): this;
+  prependOnceListener(event: 'pipe', listener: (src: ReadStream<In>) => void): this;
+  prependOnceListener(event: 'unpipe', listener: (src: ReadStream<In>) => void): this;
+  prependOnceListener(event: 'data', listener: (chunk: Out) => void): this;
+  prependOnceListener(event: 'end', listener: () => void): this;
+  prependOnceListener(event: 'readable', listener: () => void): this;
+  prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  removeListener(event: 'close', listener: () => void): this;
+  removeListener(event: 'error', listener: (err: Error) => void): this;
+  removeListener(event: 'drain', listener: () => void): this;
+  removeListener(event: 'finish', listener: () => void): this;
+  removeListener(event: 'pipe', listener: (src: ReadStream<In>) => void): this;
+  removeListener(event: 'unpipe', listener: (src: ReadStream<In>) => void): this;
+  removeListener(event: 'data', listener: (chunk: Out) => void): this;
+  removeListener(event: 'end', listener: () => void): this;
+  removeListener(event: 'readable', listener: () => void): this;
+  removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+}
+
+export interface DuplexOptions<This, In, Out> extends
+    WritableOptions<This, In>, ReadableOptions<This> {
+  allowHalfOpen?: boolean;
+  readableObjectMode?: boolean;
+  writableObjectMode?: boolean;
+}

--- a/src/util/stream/Duplex.js
+++ b/src/util/stream/Duplex.js
@@ -1,0 +1,1 @@
+export { Duplex } from 'stream';

--- a/src/util/stream/Readable.d.ts
+++ b/src/util/stream/Readable.d.ts
@@ -1,0 +1,100 @@
+import { EventEmitter } from 'events';
+import { BasicCallback } from './core';
+import { WriteStream } from './Writable';
+
+export interface Readable<T> extends ReadStream<T> {}
+export class Readable<T> {
+  constructor(opts?: ReadableOptions<Readable<T>>);
+
+  _read?(size: number): void;
+  _destroy?(error: Error | null, callback: BasicCallback): void;
+}
+
+export interface ReadStream<T> extends EventEmitter {
+  readable: boolean;
+  readonly readableHighWaterMark: number;
+  readonly readableLength: number;
+  read(size?: number): T;
+  setEncoding(encoding: string): this;
+  pause(): this;
+  resume(): this;
+  isPaused(): boolean;
+  pipe<T, S extends WriteStream<T>>(destination: S, options?: { end?: boolean; }): S;
+  unpipe<T, S extends WriteStream<T>>(destination?: S): this;
+  unshift(chunk: T): void;
+  wrap(oldStream: NodeJS.ReadableStream): this;
+  push(chunk: T | null, encoding?: string): boolean;
+  destroy(error?: Error): void;
+
+  /**
+   * Event emitter
+   * The defined events on documents including:
+   * 1. close
+   * 2. data
+   * 3. end
+   * 4. readable
+   * 5. error
+   */
+  addListener(event: 'close', listener: () => void): this;
+  addListener(event: 'data', listener: (chunk: T) => void): this;
+  addListener(event: 'end', listener: () => void): this;
+  addListener(event: 'readable', listener: () => void): this;
+  addListener(event: 'error', listener: (err: Error) => void): this;
+  addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  emit(event: 'close'): boolean;
+  emit(event: 'data', chunk: T): boolean;
+  emit(event: 'end'): boolean;
+  emit(event: 'readable'): boolean;
+  emit(event: 'error', err: Error): boolean;
+  emit(event: string | symbol, ...args: any[]): boolean;
+
+  on(event: 'close', listener: () => void): this;
+  on(event: 'data', listener: (chunk: T) => void): this;
+  on(event: 'end', listener: () => void): this;
+  on(event: 'readable', listener: () => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  once(event: 'close', listener: () => void): this;
+  once(event: 'data', listener: (chunk: T) => void): this;
+  once(event: 'end', listener: () => void): this;
+  once(event: 'readable', listener: () => void): this;
+  once(event: 'error', listener: (err: Error) => void): this;
+  once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  prependListener(event: 'close', listener: () => void): this;
+  prependListener(event: 'data', listener: (chunk: T) => void): this;
+  prependListener(event: 'end', listener: () => void): this;
+  prependListener(event: 'readable', listener: () => void): this;
+  prependListener(event: 'error', listener: (err: Error) => void): this;
+  prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  prependOnceListener(event: 'close', listener: () => void): this;
+  prependOnceListener(event: 'data', listener: (chunk: T) => void): this;
+  prependOnceListener(event: 'end', listener: () => void): this;
+  prependOnceListener(event: 'readable', listener: () => void): this;
+  prependOnceListener(event: 'error', listener: (err: Error) => void): this;
+  prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  removeListener(event: 'close', listener: () => void): this;
+  removeListener(event: 'data', listener: (chunk: T) => void): this;
+  removeListener(event: 'end', listener: () => void): this;
+  removeListener(event: 'readable', listener: () => void): this;
+  removeListener(event: 'error', listener: (err: Error) => void): this;
+  removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<T>;
+}
+
+export interface ReadableOptions<This> {
+  highWaterMark?: number;
+  encoding?: string;
+  objectMode?: boolean;
+  read?(this: This, size: number): void;
+  destroy?(
+      this: This,
+      error: Error | null,
+      callback: BasicCallback,
+      ): void;
+}

--- a/src/util/stream/Readable.js
+++ b/src/util/stream/Readable.js
@@ -1,0 +1,1 @@
+export { Readable } from 'stream';

--- a/src/util/stream/Transform.d.ts
+++ b/src/util/stream/Transform.d.ts
@@ -1,0 +1,15 @@
+import { Duplex, DuplexOptions } from './Duplex';
+
+export class Transform<In, Out> extends Duplex<In, Out> {
+  constructor(opts?: DuplexOptions<Transform<In, Out>, In, Out>)
+
+  _transform?(
+      chunk: In,
+      encoding: string,
+      callback: TransformCallback<Out>,
+      ): void;
+
+  _flush?(callback: TransformCallback<Out>): void;
+}
+
+export type TransformCallback<T> = (error?: Error, data?: T) => void;

--- a/src/util/stream/Transform.js
+++ b/src/util/stream/Transform.js
@@ -1,0 +1,1 @@
+export { Transform } from 'stream';

--- a/src/util/stream/Writable.d.ts
+++ b/src/util/stream/Writable.d.ts
@@ -1,0 +1,120 @@
+import { EventEmitter } from 'events';
+import { ReadStream } from './Readable';
+import { BasicCallback } from './core';
+
+export interface Writable<T> extends WriteStream<T> {}
+export class Writable<T> {
+  constructor(opts?: WritableOptions<Writable<T>, T>);
+
+  _write(chunk: T, encoding: string, callback: BasicCallback): void;
+  _writev?(
+      chunks: Array<{ chunk: T, encoding: string }>,
+      callback: BasicCallback,
+      ): void;
+  _destroy(error: Error | null, callback: BasicCallback): void;
+  _final(callback: BasicCallback): void;
+}
+
+export interface WriteStream<T> extends EventEmitter {
+  writable: boolean;
+  readonly writableHighWaterMark: number;
+  readonly writableLength: number;
+  write(chunk: T, cb?: (error: Error | null | undefined) => void): boolean;
+  write(chunk: T, encoding?: string, cb?: (error: Error | null | undefined) => void): boolean;
+  setDefaultEncoding(encoding: string): this;
+  end(cb?: () => void): void;
+  end(chunk: T, cb?: () => void): void;
+  end(chunk: T, encoding?: string, cb?: () => void): void;
+  cork(): void;
+  uncork(): void;
+  destroy(error?: Error): void;
+
+  /**
+   * Event emitter
+   * The defined events on documents including:
+   * 1. close
+   * 2. drain
+   * 3. error
+   * 4. finish
+   * 5. pipe
+   * 6. unpipe
+   */
+  addListener(event: 'close', listener: () => void): this;
+  addListener(event: 'drain', listener: () => void): this;
+  addListener(event: 'error', listener: (err: Error) => void): this;
+  addListener(event: 'finish', listener: () => void): this;
+  addListener(event: 'pipe', listener: (src: ReadStream<T>) => void): this;
+  addListener(event: 'unpipe', listener: (src: ReadStream<T>) => void): this;
+  addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  emit(event: 'close'): boolean;
+  emit(event: 'drain'): boolean;
+  emit(event: 'error', err: Error): boolean;
+  emit(event: 'finish'): boolean;
+  emit(event: 'pipe', src: ReadStream<T>): boolean;
+  emit(event: 'unpipe', src: ReadStream<T>): boolean;
+  emit(event: string | symbol, ...args: any[]): boolean;
+
+  on(event: 'close', listener: () => void): this;
+  on(event: 'drain', listener: () => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'finish', listener: () => void): this;
+  on(event: 'pipe', listener: (src: ReadStream<T>) => void): this;
+  on(event: 'unpipe', listener: (src: ReadStream<T>) => void): this;
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  once(event: 'close', listener: () => void): this;
+  once(event: 'drain', listener: () => void): this;
+  once(event: 'error', listener: (err: Error) => void): this;
+  once(event: 'finish', listener: () => void): this;
+  once(event: 'pipe', listener: (src: ReadStream<T>) => void): this;
+  once(event: 'unpipe', listener: (src: ReadStream<T>) => void): this;
+  once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  prependListener(event: 'close', listener: () => void): this;
+  prependListener(event: 'drain', listener: () => void): this;
+  prependListener(event: 'error', listener: (err: Error) => void): this;
+  prependListener(event: 'finish', listener: () => void): this;
+  prependListener(event: 'pipe', listener: (src: ReadStream<T>) => void): this;
+  prependListener(event: 'unpipe', listener: (src: ReadStream<T>) => void): this;
+  prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  prependOnceListener(event: 'close', listener: () => void): this;
+  prependOnceListener(event: 'drain', listener: () => void): this;
+  prependOnceListener(event: 'error', listener: (err: Error) => void): this;
+  prependOnceListener(event: 'finish', listener: () => void): this;
+  prependOnceListener(event: 'pipe', listener: (src: ReadStream<T>) => void): this;
+  prependOnceListener(event: 'unpipe', listener: (src: ReadStream<T>) => void): this;
+  prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  removeListener(event: 'close', listener: () => void): this;
+  removeListener(event: 'drain', listener: () => void): this;
+  removeListener(event: 'error', listener: (err: Error) => void): this;
+  removeListener(event: 'finish', listener: () => void): this;
+  removeListener(event: 'pipe', listener: (src: ReadStream<T>) => void): this;
+  removeListener(event: 'unpipe', listener: (src: ReadStream<T>) => void): this;
+  removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+}
+
+export interface WritableOptions<This, T> {
+  highWaterMark?: number;
+  decodeStrings?: boolean;
+  objectMode?: boolean;
+  write?(
+      this: This,
+      chunk: T,
+      encoding: string,
+      callback: BasicCallback,
+      ): void;
+  writev?(
+      this: This,
+      chunks: Array<{ chunk: T, encoding: string }>,
+      callback: BasicCallback,
+      ): void;
+  destroy?(
+      this: This,
+      error: Error | null,
+      callback: BasicCallback,
+      ): void;
+  final?(this: This, callback: BasicCallback): void;
+}

--- a/src/util/stream/Writable.js
+++ b/src/util/stream/Writable.js
@@ -1,0 +1,1 @@
+export { Writable } from 'stream';

--- a/src/util/stream/core.ts
+++ b/src/util/stream/core.ts
@@ -1,0 +1,1 @@
+export type BasicCallback = (error?: Error | null) => void;

--- a/src/util/stream/pipeline.d.ts
+++ b/src/util/stream/pipeline.d.ts
@@ -1,0 +1,56 @@
+import { WriteStream } from './Writable';
+import { ReadStream } from './Readable';
+import { ReadWriteStream } from './Duplex';
+
+
+export function pipeline<T1, Last extends WriteStream<T1>>(
+  stream1: ReadStream<T1>,
+  stream2: Last,
+  callback: PipelineCallback,
+): Last;
+export function pipeline<T1, T2, Last extends WriteStream<T2>>(
+  stream1: ReadStream<T1>,
+  stream2: ReadWriteStream<T1, T2>,
+  stream3: Last,
+  callback: PipelineCallback,
+): Last;
+export function pipeline<T1, T2, T3, Last extends WriteStream<T3>>(
+  stream1: ReadStream<T1>,
+  stream2: ReadWriteStream<T1, T2>,
+  stream3: ReadWriteStream<T2, T3>,
+  stream4: Last,
+  callback: PipelineCallback,
+): Last;
+export function pipeline<T1, T2, T3, T4, Last extends WriteStream<T4>>(
+  stream1: ReadStream<T1>,
+  stream2: ReadWriteStream<T1, T2>,
+  stream3: ReadWriteStream<T2, T3>,
+  stream4: ReadWriteStream<T3, T4>,
+  stream5: Last,
+  callback: PipelineCallback,
+): Last;
+
+export function pipelinePr<T1>(
+  stream1: ReadStream<T1>,
+  stream2: WriteStream<T1>,
+): Promise<void>;
+export function pipelinePr<T1, T2>(
+  stream1: ReadStream<T1>,
+  stream2: ReadWriteStream<T1, T2>,
+  stream3: WriteStream<T2>,
+): Promise<void>;
+export function pipelinePr<T1, T2, T3>(
+  stream1: ReadStream<T1>,
+  stream2: ReadWriteStream<T1, T2>,
+  stream3: ReadWriteStream<T2, T3>,
+  stream4: WriteStream<T3>,
+): Promise<void>;
+export function pipelinePr<T1, T2, T3, T4>(
+  stream1: ReadStream<T1>,
+  stream2: ReadWriteStream<T1, T2>,
+  stream3: ReadWriteStream<T2, T3>,
+  stream4: ReadWriteStream<T3, T4>,
+  stream5: WriteStream<T4>,
+): Promise<void>;
+
+type PipelineCallback = (err: NodeJS.ErrnoException) => void;

--- a/src/util/stream/pipeline.js
+++ b/src/util/stream/pipeline.js
@@ -1,0 +1,5 @@
+import * as stream from 'stream';
+import * as util from 'util';
+
+export const pipeline = stream.pipeline;
+export const pipelinePr = util.promisify(stream.pipeline);


### PR DESCRIPTION
Under the covers, these are just the original streams, but with modified
type definitions.

Also updates the battle stream code to use the new typed variants.