### PR TITLE
Replace ScribeJS with textual logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "SOUND IT",
   "private": true,
   "scripts": {
-    "start": "node out/server/server.js",
+    "start": "node out/server/bin/witness/witness.js",
     "updatedb": "node out/server/bin/updatedb.js",
     "build": "npm run build-server && webpack --progress --hide-modules",
     "build-server": "tsc",
@@ -14,7 +14,7 @@
     "clean": "rm -rf out/ && rm -rf static/dist/"
   },
   "engines": {
-    "node": "10.4.1"
+    "node": "11.4.0"
   },
   "dependencies": {
     "@types/bluebird": "^3.5.3",
@@ -95,6 +95,8 @@
       "node"
     ],
     "testEnvironment": "node",
-    "roots": ["test/"]
+    "roots": [
+      "test/"
+    ]
   }
 }

--- a/src/bin/witness/ProcessControl.ts
+++ b/src/bin/witness/ProcessControl.ts
@@ -1,0 +1,102 @@
+import * as child_process from 'child_process';
+import { ChildProcess } from "child_process";
+import * as logger from './logger';
+
+/**
+ * Manages the lifecycle of the child and parent processes.
+ */
+export class ProcessControl {
+  private readonly _process: NodeJS.Process;
+  private _child: ChildProcess | null = null;
+  private _isShuttingDown = false;
+  private _logsFlushed = false;
+  private _childExited = false;
+
+  constructor(process: NodeJS.Process) {
+    this._process = process;
+  }
+
+  spawnChild(childPath: string) {
+    if (this._child != null) {
+      logger.error(`Cannot spawn child "${childPath}", already have a child.`);
+      this.dieImmediately();
+    }
+
+    logger.log(`Spawning child "${childPath}"...`);
+
+    const killHandler = this._onReceiveKillSignal.bind(this);
+    process.on('SIGHUP', killHandler);
+    process.on('SIGINT', killHandler);
+    process.on('SIGQUIT', killHandler);
+    process.on('SIGTERM', killHandler);
+
+    this._child = child_process.fork(childPath, [], {
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    this._child.on('error', this._onChildError.bind(this));
+    this._child.on('exit', this._onChildExit.bind(this));
+
+    return this._child;
+  }
+
+  onLogsFlushed() {
+    this._logsFlushed = true;
+    this._checkForShutdownComplete();
+  }
+
+  dieImmediately() {
+    logger.error(`Executing emergency shutdown...`);
+    if (this._child) {
+      this._child.kill();
+      this._child.kill('SIGKILL');
+    }
+    process.exit(2);
+  }
+
+  private _onReceiveKillSignal(signal: string) {
+    logger.log(`Received ${signal}, shutting down...`);
+    this._initiateShutdown();
+  }
+
+  private _onChildError(err: Error) {
+    logger.error('Error from child process:');
+    logger.error(err);
+    this._initiateShutdown();
+  }
+
+  private _onChildExit(code: string, signal: number) {
+    logger.log('Child exited w/ code', code, 'and signal', signal);
+
+    this._childExited = true;
+    this._checkForShutdownComplete();
+    setTimeout(() => {
+      logger.error(`Logs took too long to flush, dying prematurely...`);
+      process.exit(0);
+    }, 10000);
+  }
+
+  private _initiateShutdown() {
+    if (this._isShuttingDown) {
+      // Already dying, ignore subsequent signals
+      return;
+    }
+    this._isShuttingDown = true;
+
+    if (this._child) {
+      this._child.kill();
+      setTimeout(() => {
+        logger.error('Child took too long to die, sending SIGKILL...');
+        this._child!.kill('SIGKILL');
+      }, 7000);
+    } else {
+      // No child to wait for; exit immediately
+      process.exit(0);
+    }
+  }
+
+  private _checkForShutdownComplete() {
+    if (this._logsFlushed && this._childExited) {
+      process.exit(0);
+    }
+  }
+}

--- a/src/bin/witness/RotatingFileLogWriter.ts
+++ b/src/bin/witness/RotatingFileLogWriter.ts
@@ -1,0 +1,195 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import moment = require('moment');
+import { Writable } from 'stream';
+import { WriteStream } from 'fs';
+import { BasicCallback } from '../../util/stream/core';
+import { Moment } from 'moment';
+import { asyncEach } from './asyncEach';
+import { pruneOldLogs } from './pruneOldLogs';
+import * as logger from './logger';
+import { formatLogFilename, getLogFormatSpecifier, formatOutputLine, parseInputLine } from './protocol';
+
+
+/**
+ * Writes log output to a text file.
+ *
+ * Rotates the file once every day. Deletes log files after they're older than
+ * `maxFileLifetime`.
+ */
+export class RotatingFileLogWriter extends Writable {
+  private readonly _bucketSize: moment.unitOfTime.StartOf = 'day';
+
+  private readonly _baseLogFilePath: string;
+  private readonly _maxFileLifetime: number;
+
+  private _fileStart: number | null = null;
+  private _logFileStream: WriteStream | null = null;
+
+  constructor(basePath: string, maxFileLifetime: number) {
+    super();
+    logger.log('Base logs path:', basePath);
+    this._baseLogFilePath = basePath;
+    this._maxFileLifetime = maxFileLifetime;
+  }
+
+  _write(chunk: Buffer, encoding: string, callback: BasicCallback) {
+    try {
+      this._processChunk(chunk.toString('utf8'), callback);
+    } catch (err) {
+      callback(err);
+    }
+  }
+
+  _writev?(
+      chunks: Array<{ chunk: Buffer, encoding: string }>,
+      callback: BasicCallback,
+      ): void {
+    try {
+      asyncEach(
+          chunks,
+          (entry, entryCb) => {
+            this._processChunk(entry.chunk.toString('utf8'), entryCb);
+          },
+          callback,
+          );
+    } catch (err) {
+      callback(err);
+    }
+  }
+
+  _destroy(err: Error | null, callback: (error: Error | null) => void) {
+    if (this._logFileStream != null) {
+      this._logFileStream.destroy(err || undefined);
+    }
+    // TODO: Do we need to call callback() here?
+    callback(null);
+  }
+
+  private _processChunk(chunk: string, callback: BasicCallback) {
+    const breakIndex = chunk.indexOf('\n');
+    if (breakIndex != -1 && breakIndex != chunk.length - 1) {
+      this._processMultiline(chunk, callback);
+    } else {
+      this._processLine(chunk, callback);
+    }
+  }
+
+  private _processMultiline(chunk: string, callback: BasicCallback) {
+    const splits = chunk.split('\n');
+    asyncEach(
+        splits,
+        (entry, entryCb) => {
+          this._processLine(entry, entryCb);
+        },
+        callback);
+  }
+
+  private _processLine(line: string, callback: BasicCallback) {
+    let timestamp: Moment;
+    let levelTag: string;
+    let message: string;
+
+    const match = parseInputLine(line);
+    if (match) {
+      timestamp = moment.utc(parseInt(match[1]));
+      levelTag = match[2];
+      message = match[3];
+    } else {
+      timestamp = moment.utc();
+      levelTag = 'U';
+      message = line;
+    }
+
+    let outLine = formatOutputLine(timestamp, levelTag, message);
+
+    this._getFileFor(timestamp, (err, stream) => {
+      if (err) {
+        callback(err);
+      } else {
+        if (!outLine.endsWith('\n')) {
+          outLine += '\n';
+        }
+        stream.write(outLine);
+        console.log(outLine);
+        callback();
+      }
+    });
+  }
+
+  private _getFileFor(
+      timestamp: Moment,
+      callback: (err: Error | null, stream: WriteStream) => void,
+  ) {
+    const bucketStart = timestamp.startOf(this._bucketSize);
+
+    if (this._logFileStream != null
+        && this._fileStart == bucketStart.valueOf()) {
+      callback(null, this._logFileStream);
+    } else {
+      this._rotateLogFile(bucketStart, callback);
+    }
+  }
+
+  private _rotateLogFile(
+      fileStart: Moment,
+      callback: (err: Error | null, stream: WriteStream) => void,
+  ) {
+    const newFilePath = this._getLogFilePath(fileStart);
+    logger.log('Opening log file', newFilePath);
+
+    if (this._logFileStream != null) {
+      this._logFileStream.destroy();
+    }
+    this._logFileStream = null;
+    this._fileStart = null;
+
+    pruneOldLogs(this._baseLogFilePath, this._maxFileLifetime, err => {
+      if (err) {
+        this.emit('error', err);
+      }
+    });
+
+    openFileForAppend(newFilePath, (err, stream) => {
+      if (err) {
+        callback(err, null!);
+      } else {
+        this._logFileStream = stream;
+        this._fileStart = fileStart.valueOf();
+        this._logFileStream.write(getLogFormatSpecifier());
+        callback(null, stream);
+      }
+    });
+  }
+
+  private _getLogFilePath(logStart: Moment) {
+    return path.join(
+        this._baseLogFilePath,
+        formatLogFilename(logStart),
+        );
+  }
+}
+
+function openFileForAppend(
+    filepath: string,
+    callback: (err: Error | null, stream: WriteStream) => void,
+) {
+  fs.open(filepath, 'a', (err, fd) => {
+    if (err) {
+      callback(err, null!);
+    } else {
+      const outStream = fs.createWriteStream('', {
+        fd: fd,
+        flags: 'a',
+        encoding: 'utf8',
+      });
+      callback(null, outStream);
+    }
+  });
+}
+
+const INPUT_LOG_LINE_PATTERN =
+    /^(\d+) ([EWIVD]) ?(.*)/;
+
+const TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSS[Z]';
+

--- a/src/bin/witness/asyncEach.ts
+++ b/src/bin/witness/asyncEach.ts
@@ -1,0 +1,31 @@
+import { BasicCallback } from '../../util/stream/core';
+
+/**
+ * Array iteration for callback-based async execution.
+ *
+ * For each item in the array, executes `handler()` on the item. Handlers
+ * are executed one at a time.
+ */
+export function asyncEach<T>(
+    arr: T[],
+    handler: (entry: T, callback: BasicCallback) => void,
+    callback: BasicCallback,
+) {
+  let i = 0;
+  const len = arr.length;
+  function next() {
+    if (i >= len) {
+      callback();
+    } else {
+      handler(arr[i], function(err) {
+        if (err) {
+          callback(err);
+        } else {
+          i++;
+          next();
+        }
+      })
+    }
+  }
+  next();
+}

--- a/src/bin/witness/getRootPath.ts
+++ b/src/bin/witness/getRootPath.ts
@@ -1,0 +1,20 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+let rootPathVerified = false;
+const rootPath = process.cwd();
+
+/**
+ * Checks to make sure that process.cwd() is the root of the project (by
+ * looking for the presence of `package.json`). Throws an error otherwise.
+ */
+export function getRootPath() {
+  if (!rootPathVerified) {
+    if (fs.existsSync(path.join(process.cwd(), 'package.json'))) {
+      rootPathVerified = true;
+    } else {
+      throw new Error(`Cannot find package.json in process.cwd.`);
+    }
+  }
+  return rootPath;
+}

--- a/src/bin/witness/logger.ts
+++ b/src/bin/witness/logger.ts
@@ -1,0 +1,14 @@
+
+const isProduction = process.env.NODE_ENV == 'production';
+
+const TAG = `[witness]`;
+
+export function log(...args: any[]) {
+  if (isProduction) {
+    console.log(TAG, ...args);
+  }
+}
+
+export function error(...args: any[]) {
+  console.error(TAG, ...args);
+}

--- a/src/bin/witness/protocol.ts
+++ b/src/bin/witness/protocol.ts
@@ -1,0 +1,52 @@
+import { Moment } from "moment";
+import moment = require("moment");
+
+const LOG_FILENAME_PATTERN = /^roster_logs_(\d{4}-\d{2}-\d{2}).txt$/;
+const INPUT_LOG_LINE_PATTERN = /^(\d+) ([EWIVD]) ?(.*)/;
+const OUTPUT_TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSS[Z]';
+const OUTPUT_FORMAT_VERSION = 0;
+
+export type LevelTag = 'E' | 'W' | 'I' | 'V' | 'D';
+
+/**
+ * This must be the first line of any log file. May appear later in the log
+ * file as well.
+ */
+export function getLogFormatSpecifier() {
+  return `@format:roster_log_file_${OUTPUT_FORMAT_VERSION}\n`;
+}
+
+export function formatLogFilename(logStart: Moment) {
+  return `roster_logs_${logStart.format('YYYY-MM-DD')}.txt`;
+}
+
+export function parseLogFilename(filename: string) {
+  const match = LOG_FILENAME_PATTERN.exec(filename);
+  if (!match) {
+    return null;
+  } else {
+    return moment.utc(match[1]);
+  }
+}
+
+export function formatOutputLine(
+    timestamp: Moment,
+    levelTag: string,
+    message: string,
+    ) {
+  const timestampStr = timestamp.format(OUTPUT_TIMESTAMP_FORMAT);
+  const pidStr = process.pid.toString().padStart(5);
+  return `${timestampStr} ${pidStr} ${levelTag} ${message}`;
+}
+
+export function parseInputLine(line: string) {
+  return INPUT_LOG_LINE_PATTERN.exec(line);
+}
+
+export function formatInputLine(
+    timestamp: number,
+    levelTag: LevelTag,
+    message: string,
+) {
+  return `${timestamp} ${levelTag} ${message}\n`;
+}

--- a/src/bin/witness/pruneOldLogs.ts
+++ b/src/bin/witness/pruneOldLogs.ts
@@ -1,0 +1,42 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import moment = require('moment');
+import { asyncEach } from './asyncEach';
+import { BasicCallback } from '../../util/stream/core';
+import { parseLogFilename } from './protocol';
+import * as logger from './logger';
+
+/**
+ * Deletes any log files older than MAX_LOG_LIFETIME.
+ */
+export function pruneOldLogs(
+    directory: string,
+    maxLifetime: number,
+    callback: BasicCallback,
+) {
+  fs.readdir(directory, { }, (err, files) => {
+    if (err) {
+      callback(err);
+      return;
+    }
+    asyncEach(
+        files as string[],
+        (file, callback) => {
+
+          const timestamp = parseLogFilename(file);
+
+          if (timestamp) {
+            if (moment().valueOf() - timestamp.valueOf() > maxLifetime) {
+              logger.log(`Deleting old log file "${file}".`);
+              fs.unlink(path.join(directory, file), callback)
+            } else {
+              callback();
+            }
+          } else {
+            callback();
+          }
+
+        },
+        callback);
+  });
+}

--- a/src/bin/witness/witness.ts
+++ b/src/bin/witness/witness.ts
@@ -1,0 +1,59 @@
+import * as path from 'path';
+import moment = require('moment');
+import { ProcessControl } from './ProcessControl';
+import { RotatingFileLogWriter } from './RotatingFileLogWriter';
+import { getRootPath } from './getRootPath';
+import * as logger from './logger';
+
+const CHILD_LOCATION = path.join(__dirname, '../../server.js');
+const MAX_LOG_LIFETIME = moment.duration(30, 'days').asMilliseconds();
+
+/**
+ * Parent process that writes the main server process's logs to disk
+ *
+ * It's not safe for the roster to write its own logs as it may be crashing
+ * at the time and not have enough time to complete the operation. Enter the
+ * witness process.
+ *
+ * Witness has two primary responsibilities:
+ * 1. Spawn (and possibly kill) the child process (main server)
+ * 2. Write all logs from the child process to rotating log files
+ *
+ * Witness expects the child process to log all output to process.stdout. Logs
+ * written to process.stderr will still be written to disk but ordering between
+ * concurrent stdout and stderr lines may not be properly preserved.
+ *
+ * Witness expects the child process to include a timestamp and log level on
+ * each line of output (see protocol.ts). If it doesn't, Witness will default
+ * to `error` level and use the timestamp of when it received the log line. It
+ * will also prepend "(raw)" to the log message. This may result in
+ * out-of-order timestamps in the final log.
+ */
+function main() {
+  const processControl = new ProcessControl(process);
+  const child = processControl.spawnChild(CHILD_LOCATION);
+
+  const logsPath = process.env.LOG_DIR || path.join(getRootPath(), 'logs');
+
+  const logWriter = new RotatingFileLogWriter(logsPath, MAX_LOG_LIFETIME);
+
+  logWriter.on('error', error => {
+    logger.error('Error while writing logs:');
+    logger.error(error);
+    processControl.dieImmediately();
+  });
+
+  logWriter.on('finish', () => {
+    logger.log('Logs flushed');
+    processControl.onLogsFlushed();
+  });
+
+  // There appears to be no way to get a single output stream, so we just pipe
+  // both and hope that they are ordered correctly. Our code in the child always
+  // writes to stdout, which limits our exposure here -- only 3rd party logs
+  // could possibly be written out of order.
+  child.stderr.pipe(logWriter);
+  child.stdout.pipe(logWriter);
+}
+
+main();

--- a/src/domain/srp/triage/payout.ts
+++ b/src/domain/srp/triage/payout.ts
@@ -1,5 +1,5 @@
 import { ZKillmail } from '../../../data-source/zkillboard/ZKillmail';
-import { TriageVerdict, ApprovedVerdict, MarketPayout } from './TriageRule';
+import { ApprovedVerdict, MarketPayout } from './TriageRule';
 import { fetchJitaSellPrices } from '../../../data-source/evemarketer/fetchJitaSellPrices';
 import { SrpVerdictStatus } from '../../../db/dao/enums';
 import { TriagedLoss } from './triageLosses';

--- a/src/infra/logging/WitnessLogger.ts
+++ b/src/infra/logging/WitnessLogger.ts
@@ -1,0 +1,84 @@
+import { Logger, LogLevel } from './Logger';
+import * as protocol from '../../bin/witness/protocol';
+import { printError } from '../../data-source/esi/error';
+import { nil } from '../../util/simpleTypes';
+
+export class WitnessLogger implements Logger {
+
+  private _tag: string | nil;
+
+  constructor(tag: string | nil) {
+    this._tag  = tag;
+  }
+
+  crit(message: string, error?: Error, data?: object): void {
+    this.log(LogLevel.CRIT, message, error, data);
+  }
+
+  error(message: string, error?: Error, data?: object): void {
+    this.log(LogLevel.ERROR, message, error, data);
+  }
+
+  warn(message: string, error?: Error, data?: object): void {
+    this.log(LogLevel.WARN, message, error, data);
+  }
+
+  info(message: string, data?: object): void {
+    this.log(LogLevel.INFO, message, undefined, data);
+  }
+
+  verbose(message: string, data?: object): void {
+    this.log(LogLevel.VERBOSE, message, undefined, data);
+  }
+
+  debug(message: string, data?: object): void {
+    this.log(LogLevel.DEBUG, message, undefined, data);
+  }
+
+  log(level: LogLevel, message: string, error?: Error, data?: object): void {
+    const levelTag = logLevelToProtocolTag(level);
+    logMessage(levelTag, this._formatMessage(message, data));
+    if (error) {
+      logMessage(levelTag, printError(error));
+    }
+  }
+
+  private _formatMessage(message: string, data: object | undefined) {
+    let formatted = this._tag ? `[${this._tag}] ${message}` : message;
+
+    if (data == undefined) {
+      return formatted;
+    } else {
+      return `${formatted} ${JSON.stringify(data)}`;
+    }
+  }
+}
+
+function logMessage(level: protocol.LevelTag, message: string) {
+  if (message.indexOf('\n') == -1) {
+    process.stdout.write(
+        protocol.formatInputLine(Date.now(), level, message));
+  } else {
+    const lines = message.split('\n');
+    for (let line of lines) {
+      logMessage(level, line);
+    }
+  }
+}
+
+function logLevelToProtocolTag(level: LogLevel): protocol.LevelTag {
+  switch (level) {
+    case LogLevel.CRIT:
+      return 'E';
+    case LogLevel.ERROR:
+      return 'E';
+    case LogLevel.WARN:
+      return 'W';
+    case LogLevel.INFO:
+      return 'I';
+    case LogLevel.VERBOSE:
+      return 'V';
+    case LogLevel.DEBUG:
+      return 'D';
+  }
+}

--- a/src/infra/logging/buildLogger.ts
+++ b/src/infra/logging/buildLogger.ts
@@ -1,5 +1,5 @@
 import { Logger } from './Logger';
-import { ScribeJsWrapper } from './ScribeJsWrapper';
+import { WitnessLogger } from './WitnessLogger';
 
 /**
  * Creates an object that can be used to log messages to persistent logs.
@@ -13,7 +13,7 @@ import { ScribeJsWrapper } from './ScribeJsWrapper';
  *    name).
  */
 export function buildLogger(tag: string): Logger {
-  return new ScribeJsWrapper(tag);
+  return new WitnessLogger(tag);
 }
 
 /**
@@ -21,7 +21,7 @@ export function buildLogger(tag: string): Logger {
  * filename. Example usage: <code>buildLoggerFromFilename(__filename);</code>.
  */
 export function buildLoggerFromFilename(filename: string): Logger {
-  return new ScribeJsWrapper(extractTagFromFilename(filename));
+  return new WitnessLogger(extractTagFromFilename(filename));
 }
 
 const FILENAME_PATTERN = /([^/]+)(\.[^/]+)$/;

--- a/src/infra/taskrunner/cron.ts
+++ b/src/infra/taskrunner/cron.ts
@@ -25,7 +25,7 @@ export interface TaskSchedule {
 
 export function init(db: Tnex) {
   if (process.env.DEBUG_DISABLE_CRON == 'true') {
-    console.warn(`*** WARNING: Cron has been disabled via env flag. ***`);
+    logger.warn(`*** WARNING: Cron has been disabled via env flag. ***`);
   } else {
     new Cron(db).init();
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,7 +29,7 @@ process.on('unhandledRejection', (err) => {
 
 for (let envVar of REQUIRED_VARS) {
   if (!(envVar in process.env)) {
-    console.error(`Missing config param ${envVar} (check your .env file).`);
+    logger.error(`Missing config param ${envVar} (check your .env file).`);
     process.exit(2);
   }
 }

--- a/src/util/express/schemaVerifier.ts
+++ b/src/util/express/schemaVerifier.ts
@@ -214,6 +214,11 @@ class ArraySchema extends Schema {
   verify(value: any, path: string[]) {
     super.verify(value, path);
 
+    if (value == undefined) {
+      // Whether this is allowed has already been checked by the super call.
+      return;
+    }
+
     if (!(value instanceof Array)) {
       throw new SchemaVerificationError(
           `Property ${pathToStr(path)} must be an array.`);


### PR DESCRIPTION
Instead of logging to JSON, we revert to logging to a textual format that's
easy to grep. Moves the actual logging to a separate process (`witness`)
so that output from crashes is still logged correctly.

The `witness` process is now the first process to be started. It then spawns
the actual server as a child process. It reads all stdout/stderr output from
the child and writes it to a rotating text file.