### PR TITLE
Remove deprecated scopes

### DIFF
--- a/src/domain/sso/loginParams.ts
+++ b/src/domain/sso/loginParams.ts
@@ -51,7 +51,6 @@ export const LOGIN_PARAMS = querystring.stringify({
     'esi-fittings.write_fittings.v1',
     'esi-markets.structure_markets.v1',
     'esi-corporations.read_structures.v1',
-    'esi-corporations.write_structures.v1',
     'esi-characters.read_loyalty.v1',
     'esi-characters.read_opportunities.v1',
     'esi-characters.read_chat_channels.v1',
@@ -91,7 +90,6 @@ export const LOGIN_PARAMS = querystring.stringify({
     'esi-alliances.read_contacts.v1',
     'esi-characters.read_fw_stats.v1',
     'esi-corporations.read_fw_stats.v1',
-    'esi-corporations.read_outposts.v1',
     'esi-characterstats.read.v1',
   ].join(' '),
 });


### PR DESCRIPTION
See https://developers.eveonline.com/blog/article/removal-of-scopes-from-sso

I tested that this gets rid of the 500 error on login; I haven't really tested functionality beyond that, but I don't think we should depend on these scopes anywhere. 