### PR TITLE
Simple UI for borrowed ships.

### DIFF
--- a/src/client/home.js
+++ b/src/client/home.js
@@ -20,6 +20,9 @@ import PaymentTriage from './srp/PaymentTriage.vue';
 import PaymentDetail from './srp/PaymentDetail.vue';
 import BattleDetail from './srp/battles/BattleDetail.vue';
 
+import ShipsBorrowedByMe from './ships/ShipsBorrowedByMe.vue';
+import AllBorrowedShips from './ships/AllBorrowedShips.vue';
+
 
 // Anything added here should also be in server.js:FRONTEND_ROUTES
 // TODO(aiiane): make server.js just read it directly from here
@@ -92,6 +95,9 @@ const routes = [
     component: BattleDetail,
     props: (route) => ({ battleId: parseInt(route.params.id) }),
   },
+  { path: '/ships', redirect: '/ships/borrowed-by-me', },
+  { path: '/ships/borrowed-by-me', component: ShipsBorrowedByMe, },
+  { path: '/ships/borrowed-all', component: AllBorrowedShips, },
 ];
 if (process.env.NODE_ENV == 'development') {
   routes.push(

--- a/src/client/shared/AppHeader.vue
+++ b/src/client/shared/AppHeader.vue
@@ -2,7 +2,7 @@
   <div class="header">
     <eve-image :id="99000739" type="Alliance" :size="40" class="app-icon" />
     <router-link to="/" class="nav-link" exact>Dashboard</router-link>
-    <router-link 
+    <router-link
         to="/roster"
         v-if="canReadRoster"
         class="nav-link"
@@ -12,6 +12,11 @@
         v-if="identity.isMember"
         class="nav-link"
         >SRP</router-link>
+    <router-link
+        to="/ships"
+        v-if="identity.isMember"
+        class="nav-link"
+        >Ships</router-link>
     <router-link
         to="/admin"
         v-if="canAccessAdminConsole"

--- a/src/client/shared/ajaxer.js
+++ b/src/client/shared/ajaxer.js
@@ -194,6 +194,14 @@ export default {
     });
   },
 
+  getAllBorrowedShips() {
+    return axios.get('/api/ships/borrowed');
+  },
+
+  getShipsBorrowedByMe() {
+    return axios.get('/api/ships/borrowedByMe');
+  },
+
   postOpenInformationWindow(character, targetId) {
     return axios.post(`/api/control/openwindow/information`, {
       character: character,

--- a/src/client/ships/AllBorrowedShips.vue
+++ b/src/client/ships/AllBorrowedShips.vue
@@ -1,0 +1,45 @@
+<template>
+  <ships-wrapper title="All borrowed corp ships" :identity="identity">
+    <loading-spinner
+      class="main-spinner"
+      ref="spinner"
+      defaultState="hidden"
+      size="34px"
+    />
+    <ship-table :ships="ships" :showMainCharacter="true" />
+  </ships-wrapper>
+</template>
+
+<script>
+import ajaxer from '../shared/ajaxer';
+
+import ShipsWrapper from './ShipsWrapper.vue';
+import ShipTable from './ShipTable.vue';
+import LoadingSpinner from '../shared/LoadingSpinner.vue';
+
+export default {
+  components: {
+    ShipsWrapper,
+    ShipTable,
+    LoadingSpinner,
+  },
+
+  props: {
+    identity: { type: Object, required: true },
+  },
+
+  data: function() {
+    return {
+      ships: [],
+    };
+  },
+
+  mounted: function() {
+    this.$refs.spinner
+      .observe(ajaxer.getAllBorrowedShips())
+      .then((response) => {
+        this.ships = response.data;
+      });
+  },
+};
+</script>

--- a/src/client/ships/ShipTable.vue
+++ b/src/client/ships/ShipTable.vue
@@ -1,0 +1,105 @@
+<template>
+  <table class="table" v-if="ships.length">
+    <thead>
+      <tr>
+        <th class="char-name" v-if="showMainCharacter">Main</th>
+        <th class="char-name">Character</th>
+        <th class="ship-type">Type</th>
+        <th class="ship-name">Name</th>
+        <th class="ship-loc">Location</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="ship-row" v-for="ship in sorted(ships)" :key="ship.id">
+        <td v-if="showMainCharacter">{{ ship.mainCharacterName }}</td>
+        <td>{{ ship.characterName }}</td>
+        <td>{{ ship.type }}</td>
+        <td>{{ ship.name }}</td>
+        <td>{{ ship.locationDescription }}</td>
+      </tr>
+    </tbody>
+  </table>
+  <div class="empty-list" v-else>
+    No borrowed corp ships found. Neat!
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    showMainCharacter: { type: Boolean, required: false, default: false },
+    ships: { type: Array, required: true },
+  },
+
+  methods: {
+    sorted: function(inp) {
+      let ships = inp.slice();
+      ships.sort((a, b) => {
+        if (a.mainCharacterName !== b.mainCharacterName) {
+          return a.mainCharacterName.localeCompare(b.mainCharacterName);
+        }
+        if (a.characterName !== b.characterName) {
+          return a.characterName.localeCompare(b.characterName);
+        }
+        if (a.locationDescription !== b.locationDescription) {
+          return a.locationDescription.localeCompare(b.locationDescription);
+        }
+        return a.type.localeCompare(b.type);
+      });
+      return ships;
+    },
+  },
+};
+</script>
+
+<style scoped>
+table {
+  table-layout: fixed;
+  text-align: left;
+  font-size: 14px;
+  width: 95%;
+  border-collapse: collapse;
+}
+
+thead th.char-name {
+  width: 12%;
+}
+
+thead th.ship-type {
+  width: 8%;
+}
+
+thead th.ship-name {
+  width: 16%;
+}
+
+thead th.ship-loc {
+  width: 40%;
+}
+
+th,
+td {
+  padding: 10px 8px;
+}
+
+th {
+  font-weight: normal;
+  color: #a7a29c;
+  padding-bottom: 5px;
+}
+
+tbody tr:nth-child(even) {
+  background-color: #181818;
+}
+
+tbody tr:nth-child(odd) {
+  background-color: #131313;
+}
+
+div.empty-list {
+  font-size: 14px;
+  width: 95%;
+  padding: 10px 8px;
+  background-color: #181818;
+}
+</style>

--- a/src/client/ships/ShipsBorrowedByMe.vue
+++ b/src/client/ships/ShipsBorrowedByMe.vue
@@ -1,0 +1,45 @@
+<template>
+  <ships-wrapper title="Corp ships in my hangars" :identity="identity">
+    <loading-spinner
+      class="main-spinner"
+      ref="spinner"
+      defaultState="hidden"
+      size="34px"
+    />
+    <ship-table :ships="ships" :showMainCharacter="false" />
+  </ships-wrapper>
+</template>
+
+<script>
+import ajaxer from '../shared/ajaxer';
+
+import ShipsWrapper from './ShipsWrapper.vue';
+import ShipTable from './ShipTable.vue';
+import LoadingSpinner from '../shared/LoadingSpinner.vue';
+
+export default {
+  components: {
+    ShipsWrapper,
+    ShipTable,
+    LoadingSpinner,
+  },
+
+  props: {
+    identity: { type: Object, required: true },
+  },
+
+  data: function() {
+    return {
+      ships: [],
+    };
+  },
+
+  mounted: function() {
+    this.$refs.spinner
+      .observe(ajaxer.getShipsBorrowedByMe())
+      .then((response) => {
+        this.ships = response.data;
+      });
+  },
+};
+</script>

--- a/src/client/ships/ShipsWrapper.vue
+++ b/src/client/ships/ShipsWrapper.vue
@@ -1,0 +1,89 @@
+<template>
+  <div>
+    <app-header :identity="identity"></app-header>
+    <div class="split-container">
+      <div class="sidebar">
+        <router-link class="sidebar-link" to="/ships/borrowed-by-me">
+          Borrowed by me
+        </router-link>
+        <router-link
+          class="sidebar-link"
+          to="/ships/borrowed-all"
+          v-if="canSeeAllBorrowedShips"
+        >
+          All borrowed ships
+        </router-link>
+      </div>
+      <div class="main">
+        <div class="title">{{ title }}</div>
+        <slot></slot>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import AppHeader from '../shared/AppHeader.vue';
+
+export default {
+  components: {
+    AppHeader,
+  },
+
+  props: {
+    identity: { type: Object, required: true },
+    title: { type: String, required: true },
+  },
+
+  computed: {
+    canSeeAllBorrowedShips() {
+      return this.identity.access['characterShips'] >= 1;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.split-container {
+  display: flex;
+  font-weight: 300;
+  width: 1200px;
+  margin: 0 auto;
+}
+
+.sidebar {
+  width: 230px;
+  flex: 0 0 auto;
+  padding-left: 33px;
+  padding-top: 40px;
+}
+
+.sidebar-link {
+  display: block;
+  font-size: 14px;
+  color: #a7a29c;
+  margin-bottom: 14px;
+  text-decoration: none;
+}
+
+.sidebar-link:hover {
+  text-decoration: underline;
+}
+
+.sidebar-link.router-link-active {
+  color: #d7d7d7;
+  text-shadow: 0 0 6px rgba(166, 116, 54, 58);
+  text-decoration: none;
+}
+
+.main {
+  flex: 1;
+}
+
+.title {
+  font-size: 30px;
+  color: #a7a29c;
+  font-weight: 100;
+  margin: 40px 0 40px 0;
+}
+</style>

--- a/src/db/dao/CharacterShipDao.ts
+++ b/src/db/dao/CharacterShipDao.ts
@@ -85,6 +85,7 @@ export default class CharacterShipDao {
         'mainChar_name',
         'character_name',
         'styp_name',
+        'characterShip_id',
         'characterShip_name',
         'characterShip_locationDescription',
         'characterShipUpdate_timestamp'
@@ -99,6 +100,7 @@ export default class CharacterShipDao {
     return rows.map(
       (r) =>
         <BorrowedShipOutputRow>{
+          id: r.characterShip_id,
           mainCharacterName: r.mainChar_name,
           characterName: r.character_name,
           type: r.styp_name,
@@ -119,6 +121,7 @@ export interface CharacterShipRow {
 }
 
 export interface BorrowedShipOutputRow {
+  id: number;
   mainCharacterName: string;
   characterName: string;
   type: string;

--- a/src/infra/express/express.ts
+++ b/src/infra/express/express.ts
@@ -28,6 +28,8 @@ const FRONTEND_ROUTES = [
   '/dev/:section',
   '/srp',
   '/srp/*',
+  '/ships',
+  '/ships/*',
 ];
 
 export async function init(db: Tnex, onServing: (port: number) => void) {

--- a/src/route/home.ts
+++ b/src/route/home.ts
@@ -9,6 +9,7 @@ export default htmlEndpoint(async (req, res, db, account, privs) => {
         [
           'roster',
           'adminConsole',
+          'characterShips',
           'srp',
         ],
         false


### PR DESCRIPTION
Add two pages under "Ships" item in the top navigation bar. One, accessible
to all members, shows all ships borrowed by the characters attached to the
current account. The other, restricted to admins, lists all borrowed
ships for the entire corp.