### PR TITLE
don't contend on shared 'cron' channel

### DIFF
--- a/src/task-registry/scheduledTasks.ts
+++ b/src/task-registry/scheduledTasks.ts
@@ -73,6 +73,7 @@ export const SCHEDULED_TASKS: TaskSchedule[] = [
     task: syncNotifications,
     schedule: "27 * * * * *", // 27th second of every minute
     interval: moment.duration(1, "minutes").asMilliseconds(),
+    notification: "notification",
     silent: true,
   },
 ];

--- a/src/task-registry/scheduledTasks.ts
+++ b/src/task-registry/scheduledTasks.ts
@@ -73,7 +73,7 @@ export const SCHEDULED_TASKS: TaskSchedule[] = [
     task: syncNotifications,
     schedule: "27 * * * * *", // 27th second of every minute
     interval: moment.duration(1, "minutes").asMilliseconds(),
-    notification: "notification",
+    channel: "notification",
     silent: true,
   },
 ];


### PR DESCRIPTION
otherwise long running maintenance functions such as `syncCorps' may stop us for running for minutes at a time.