### PR TITLE
use different form of dokku sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           name: SSH key for of-sound-mind.com
           command: ssh-keyscan of-sound-mind.com >> ~/.ssh/known_hosts
       - run:
-          name: Deploy Master to dokku staging
+          name: Deploy to dokku staging using preconfigured ssh key and server-side command
           command: ssh -N dokku@of-sound-mind.com
 workflows:
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           command: ssh-keyscan of-sound-mind.com >> ~/.ssh/known_hosts
       - run:
           name: Deploy Master to dokku staging
-          command: git push dokku@of-sound-mind.com:roster-staging master
+          command: ssh -N dokku@of-sound-mind.com
 workflows:
   build-and-test:
     jobs:


### PR DESCRIPTION
`dokku git:sync --build roster-staging https://github.com/eve-val/eve-roster.git master` will run automatically, as COMMAND is overridden.