### PR TITLE
don't set corpid to -1

### DIFF
--- a/src/task/syncCorps.ts
+++ b/src/task/syncCorps.ts
@@ -78,6 +78,12 @@ function updateCorporation(db: Tnex, characterId: number) {
       return fetchEsi(ESI_CHARACTERS_$characterId, { characterId });
     })
     .then((character) => {
+      if (character.corporation_id == -1) {
+        throw new EsiError(
+          CLIENT_ERROR,
+          `Invalid corporation while fetching "${characterId}"`,
+        );
+      }
       return dao.character.updateCharacter(db, characterId, {
         character_corporationId: character.corporation_id,
       });


### PR DESCRIPTION
for some reason an esi error still resulted in some slipping of -1 into peoples' corp ids when the catch should have been called