### PR TITLE
remove @types/terser-webpack; bump node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,22 +20,22 @@ workflows:
   build-and-test:
     jobs:
       - node/test:
-          version: 14.17.5
+          version: 14.17.6
           pkg-manager: yarn
           run-command: jest
           name: jest
       - node/test:
-          version: 14.17.5
+          version: 14.17.6
           pkg-manager: yarn
           run-command: pretty-check
           name: pretty-check
       - node/test:
-          version: 14.17.5
+          version: 14.17.6
           pkg-manager: yarn
           run-command: lint
           name: lint
       - node/test:
-          version: 14.17.5
+          version: 14.17.6
           pkg-manager: yarn
           run-command: build
           name: build

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@types/source-map-support": "^0.5.4",
     "@types/sqlite3": "^3.1.7",
     "@types/svgo": "^2.4.1",
-    "@types/terser-webpack-plugin": "^5.0.3",
     "@types/tmp": "^0.2.1",
     "@types/underscore": "^1.11.3",
     "@types/verror": "^1.10.5",
@@ -147,6 +146,6 @@
     }
   },
   "engines": {
-    "node": "14.17.5"
+    "node": "14.17.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,14 +1285,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/terser-webpack-plugin@^5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@types/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz#9194c24dee3a9d5dcfd67b58edffc1d66653d16b"
-  integrity sha512-Ef60BOY9hV+yXjkMCuJI17cu1R8/H31n5Rnt1cElJFyBSkbRV3UWyBIYn8YpijsOG05R4bZf3G2azyBHkksu/A==
-  dependencies:
-    terser "^5.3.8"
-    webpack "^5.1.0"
-
 "@types/tmp@^0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.1.tgz#83ecf4ec22a8c218c71db25f316619fe5b986011"
@@ -8896,7 +8888,7 @@ terser@^4.6.3:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.3.8, terser@^5.7.2:
+terser@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.7.2.tgz#d4d95ed4f8bf735cb933e802f2a1829abf545e3f"
   integrity sha512-0Omye+RD4X7X69O0eql3lC4Heh/5iLj3ggxR/B5ketZLOtLiOqukUgjw3q4PDnNQbsrkKr3UMypqStQG3XKRvw==
@@ -9508,7 +9500,7 @@ webpack-sources@^2.3.0:
     source-list-map "^2.0.1"
     source-map "^0.6.1"
 
-webpack@^5, webpack@^5.1.0, webpack@^5.37.0, webpack@^5.37.1, webpack@^5.38.1:
+webpack@^5, webpack@^5.37.0, webpack@^5.37.1, webpack@^5.38.1:
   version "5.38.1"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.38.1.tgz#5224c7f24c18e729268d3e3bc97240d6e880258e"
   integrity sha512-OqRmYD1OJbHZph6RUMD93GcCZy4Z4wC0ele4FXyYF0J6AxO1vOSuIlU1hkS/lDlR9CDYBz64MZRmdbdnFFoT2g==


### PR DESCRIPTION
as per https://github.com/eve-val/eve-roster/pull/730 terser-webpack-plugin has its own types