### PR TITLE
revert imagemin-svgo to 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "imagemin-gifsicle": "^7.0.0",
     "imagemin-mozjpeg": "^9.0.0",
     "imagemin-pngquant": "^9.0.2",
-    "imagemin-svgo": "^10.0.0",
+    "imagemin-svgo": "^9.0.0",
     "jest": "^27.2.0",
     "json-loader": "^0.5.7",
     "mini-css-extract-plugin": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4942,13 +4942,13 @@ imagemin-pngquant@^9.0.2:
     ow "^0.17.0"
     pngquant-bin "^6.0.0"
 
-imagemin-svgo@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/imagemin-svgo/-/imagemin-svgo-10.0.0.tgz#0cc0c5636dc707ae96c580836c79922601da9b34"
-  integrity sha512-nuikUDlf8u81V25ckHrWE8l7fECNx403EU3a3qrSO8H4ipBSEL3QlOgrBqZ1SJQ1lsIzJbBKwXvsrVGGO6Hj2g==
+imagemin-svgo@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/imagemin-svgo/-/imagemin-svgo-9.0.0.tgz#749370804608917a67d4ff590f07a87756aec006"
+  integrity sha512-uNgXpKHd99C0WODkrJ8OO/3zW3qjgS4pW7hcuII0RcHN3tnKxDjJWcitdVC/TZyfIqSricU8WfrHn26bdSW62g==
   dependencies:
-    is-svg "^4.3.1"
-    svgo "^2.5.0"
+    is-svg "^4.2.1"
+    svgo "^2.1.0"
 
 imagemin@^7.0.1:
   version "7.0.1"
@@ -5297,7 +5297,7 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
-is-svg@^4.3.1:
+is-svg@^4.2.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-4.3.1.tgz#8c63ec8c67c8c7f0a8de0a71c8c7d58eccf4406b"
   integrity sha512-h2CGs+yPUyvkgTJQS9cJzo9lYK06WgRiXUqBBHtglSzVKAuH4/oWsqk7LGfbSa1hGk9QcZ0SyQtVggvBA8LZXA==
@@ -9002,7 +9002,7 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-svgo@^2.3.0, svgo@^2.5.0, svgo@^2.6.1:
+svgo@^2.1.0, svgo@^2.3.0, svgo@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-2.6.1.tgz#60b613937e0081028cffc2369090e366b08f1f0e"
   integrity sha512-SDo274ymyG1jJ3HtCr3hkfwS8NqWdF0fMr6xPlrJ5y2QMofsQxIEFWgR1epwb197teKGgnZbzozxvJyIeJpE2Q==


### PR DESCRIPTION
Until https://github.com/webpack-contrib/image-minimizer-webpack-plugin/issues/237 is solved, we need to roll back imagemin-svgo

Solves these errors that have cropped up the past 2 weeks:

```
WARNING in ./src/client/shared/res/LoadingSpinner-spinner.svg
Module Warning (from ./node_modules/image-minimizer-webpack-plugin/dist/loader.js):
Unknown plugin: imagemin-svgo

Did you forget to install the plugin?
You can install it with:

$ npm install imagemin-svgo --save-dev
$ yarn add imagemin-svgo --dev
 @ ./node_modules/vue-loader/dist/templateLoader.js??ruleSet[1].rules[1]!./node_modules/vue-loader/dist/index.js??ruleSet[1].rules[7].use[0]!./src/client/shared/LoadingSpinner.vue?vue&type=template&id=440c8cdd&scoped=true 2:0-57 27:21-31
 @ ./src/client/shared/LoadingSpinner.vue?vue&type=template&id=440c8cdd&scoped=true 1:0-232 1:0-232
 @ ./src/client/shared/LoadingSpinner.vue 1:0-87 6:16-22
 @ ./node_modules/ts-loader/index.js??clonedRuleSet-1!./node_modules/vue-loader/dist/index.js??ruleSet[1].rules[7].use[0]!./src/client/admin/AccountLog.vue?vue&type=script&lang=ts
 @ ./src/client/admin/AccountLog.vue?vue&type=script&lang=ts 1:0-202 1:0-202 1:203-394 1:203-394
 @ ./src/client/admin/AccountLog.vue 2:0-61 3:0-56 3:0-56 6:0-13 7:0-16 9:15-21
 @ ./src/client/home.ts
```