### PR TITLE
Revert "cache yarn/cache, not node_modules"

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,8 +164,5 @@
   "volta": {
     "node": "16.13.2"
   },
-  "cacheDirectories": [
-    ".yarn/cache"
-  ],
   "packageManager": "yarn@3.2.0-rc.13"
 }


### PR DESCRIPTION
Reverts eve-val/eve-roster#930