### PR TITLE
Adjust Dokku port env vars to be optional

### DIFF
--- a/src/infra/init/Env.ts
+++ b/src/infra/init/Env.ts
@@ -19,10 +19,10 @@ export function initEnv() {
     HOSTNAME: str({ devDefault: "localhost" }),
     PORT: int({ devDefault: 8081 }),
 
-    DOKKU_NGINX_PORT: int({ devDefault: undefined }),
-    DOKKU_PROXY_PORT: int({ devDefault: undefined }),
-    DOKKU_NGINX_SSL_PORT: int({ devDefault: undefined }),
-    DOKKU_PROXY_SSL_PORT: int({ devDefault: undefined }),
+    DOKKU_NGINX_PORT: int({ default: undefined }),
+    DOKKU_PROXY_PORT: int({ default: undefined }),
+    DOKKU_NGINX_SSL_PORT: int({ default: undefined }),
+    DOKKU_PROXY_SSL_PORT: int({ default: undefined }),
 
     HONEYCOMB_API_KEY: str({ devDefault: "" }),
     HONEYCOMB_DATASET: str({ devDefault: "" }),


### PR DESCRIPTION
It looks like our current environment does not use DOKKU_NGINX_PORT or DOKKU_NGINX_SSL_PORT, but the server is actually designed to function correctly even if none of them are set.