### PR TITLE
Revert "Bump typescript from 4.8.2 to 4.8.4"

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "ts-jest": "^28.0.8",
     "ts-jest-resolver": "^2.0.0",
     "ts-loader": "^9.3.1",
-    "typescript": "^4.8.4",
+    "typescript": "^4.8.2",
     "url": "^0.11.0",
     "vue": "^3.2.41",
     "vue-eslint-parser": "^9.1.0",

--- a/src/db/getPostgresKnex.ts
+++ b/src/db/getPostgresKnex.ts
@@ -1,6 +1,6 @@
 import pg from "pg";
 
-import { knex, Knex } from "knex";
+import { default as knex, Knex } from "knex";
 
 // By default, pg returns columns of type "bigint" (20) as strings, not numbers,
 // since they could possibly overflow Javascript's number type (which is a
@@ -52,5 +52,5 @@ export function getPostgresKnex() {
     (pgKnex as any).CLIENT = CLIENT;
   }
 
-  return pgKnex!;
+  return pgKnex;
 }

--- a/src/infra/express/express.ts
+++ b/src/infra/express/express.ts
@@ -1,5 +1,5 @@
 import { default as Graceful } from "node-graceful";
-Graceful.default.captureExceptions = true;
+Graceful.captureExceptions = true;
 
 import * as Sentry from "@sentry/node";
 
@@ -112,7 +112,7 @@ export async function init(db: Tnex, onServing: (port: number) => void) {
     onServing(port);
   });
 
-  Graceful.default.on("exit", async () => {
+  Graceful.on("exit", async () => {
     await server.close();
   });
 }

--- a/src/infra/init/initMonitoring.ts
+++ b/src/infra/init/initMonitoring.ts
@@ -37,8 +37,8 @@ export function initMonitoring(env: Env) {
   provider.addSpanProcessor(new BatchSpanProcessor(exporter));
   provider.register();
 
-  Graceful.default.captureExceptions = true;
-  Graceful.default.on("exit", async () => {
+  Graceful.captureExceptions = true;
+  Graceful.on("exit", async () => {
     await provider.shutdown();
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,11 +4,11 @@
     "outDir": "./out/server",
     "incremental": true,
 
-    "target": "es2022",
+    "target": "es2020",
     // Export Node-style modules since this is running on Node
-    "module": "node16",
+    "module": "nodenext",
     // We're running on Node, so use this strategy.
-    "moduleResolution": "node16",
+    "moduleResolution": "nodenext",
 
     // Various strictness guarantees when compiling
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5330,7 +5330,7 @@ __metadata:
     ts-jest: "npm:^28.0.8"
     ts-jest-resolver: "npm:^2.0.0"
     ts-loader: "npm:^9.3.1"
-    typescript: "npm:^4.8.4"
+    typescript: "npm:^4.8.2"
     unbzip2-stream: "npm:^1.4.3"
     underscore: "npm:^1.13.6"
     url: "npm:^0.11.0"
@@ -12645,23 +12645,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.8.4":
-  version: 4.8.4
-  resolution: "typescript@npm:4.8.4"
+"typescript@npm:^4.8.2":
+  version: 4.8.2
+  resolution: "typescript@npm:4.8.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 008c336ed785130b6e13254adbfc4084f5dbbe62851df9bac3eaf62fc29e0a396839c00ce47e0d92db44fa9a08b9f7ba4d31304f2b10cf7d42a0817728e822a1
+  checksum: 67ffddd3d17e9f998a184925725222bfb63aab9d786542879006cff335e897c3a386b9ee564c0a5dc65e5b97cd3c66914096b1b60b9e418171cde2894cc994a8
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^4.8.4#optional!builtin<compat/typescript>":
-  version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#optional!builtin<compat/typescript>::version=4.8.4&hash=701156"
+"typescript@patch:typescript@npm%3A^4.8.2#optional!builtin<compat/typescript>":
+  version: 4.8.2
+  resolution: "typescript@patch:typescript@npm%3A4.8.2#optional!builtin<compat/typescript>::version=4.8.2&hash=701156"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 72574875bac1c13aec22010780d4841a10a88342d73744dbbad538bb0ed601f2024187f197239f2dcbf2442f83ecc4de04a80941d49730c403969fbba035ed81
+  checksum: d9756ca701560f13bff90b078f3641835450cab0168f6bd1cd03aa8a25440474a3b9d5df0a9d0486cc5d633b04009f505993cec175dea6142e541501c73be68e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts eve-val/eve-roster#1381

Deploy was unclean, let's try that again later.