### PR TITLE
Revert "Bump @vue/runtime-dom from 3.2.37 to 3.2.45"

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
     "@vue/compiler-sfc": "^3.2.45",
-    "@vue/runtime-dom": "^3.2.45",
+    "@vue/runtime-dom": "^3.2.37",
     "buffer": "^6.0.3",
     "clean-webpack-plugin": "^4.0.0",
     "cleanup-mini-css-extract-plugin": "^1.1.1",
@@ -142,7 +142,7 @@
     "webpack-merge": "^5.8.0"
   },
   "resolutions": {
-    "@vue/runtime-dom": "3.2.45",
+    "@vue/runtime-dom": "3.2.37",
     "find-versions": "^5",
     "lpad-align": "^3.0.0",
     "strip-ansi": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2451,33 +2451,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/reactivity@npm:3.2.45":
-  version: 3.2.45
-  resolution: "@vue/reactivity@npm:3.2.45"
+"@vue/reactivity@npm:3.2.37":
+  version: 3.2.37
+  resolution: "@vue/reactivity@npm:3.2.37"
   dependencies:
-    "@vue/shared": "npm:3.2.45"
-  checksum: 8462aeaa10dc3f19c7d1a6dd4937a69c61122e18c5bfe2efcc4fb6d1d640ef9d3a31b7c176a5b0564d38e84f7e518f28881616068c1adca0cd5ddcc6891f58b8
+    "@vue/shared": "npm:3.2.37"
+  checksum: b956ee2075dd0e3dd6c41baa0a336ab5840774e8a3956326e25f7257e6ed0a3ff3622a5371f00416bc5c93d13b35b274801537594ad3eaed080f976909046684
   languageName: node
   linkType: hard
 
-"@vue/runtime-core@npm:3.2.45":
-  version: 3.2.45
-  resolution: "@vue/runtime-core@npm:3.2.45"
+"@vue/runtime-core@npm:3.2.37":
+  version: 3.2.37
+  resolution: "@vue/runtime-core@npm:3.2.37"
   dependencies:
-    "@vue/reactivity": "npm:3.2.45"
-    "@vue/shared": "npm:3.2.45"
-  checksum: 76f9d9c505ec1fa75f662d9eec0bf5b03ebb2c3d25c54876bab0a166e1817414d1904c0799fa257196ac39797ea4879d1b4ec859f96c8e6e7cd88e1715aa1d32
+    "@vue/reactivity": "npm:3.2.37"
+    "@vue/shared": "npm:3.2.37"
+  checksum: 2ad2fd614f1f76529ce1a25541a13248e686803e8ed0cb08314156b04e01c5ff3888168b3571dde74a48d573f8b69ec240c403d688f60833eb185b44022da061
   languageName: node
   linkType: hard
 
-"@vue/runtime-dom@npm:3.2.45":
-  version: 3.2.45
-  resolution: "@vue/runtime-dom@npm:3.2.45"
+"@vue/runtime-dom@npm:3.2.37":
+  version: 3.2.37
+  resolution: "@vue/runtime-dom@npm:3.2.37"
   dependencies:
-    "@vue/runtime-core": "npm:3.2.45"
-    "@vue/shared": "npm:3.2.45"
+    "@vue/runtime-core": "npm:3.2.37"
+    "@vue/shared": "npm:3.2.37"
     csstype: "npm:^2.6.8"
-  checksum: 5ff0720bb3af5441492e9fb6e8793e4b116291762c54732aa11d4147641d2e916c41276e9da489cff136c6bc0bbeef479a7cef9c0aa3d27c8085913015240818
+  checksum: 488112a96295af7082398b1730216e4eb817ad28f0911848d4f22db560d9e5fd4c9a6b696da199eb42c2dc59aa49d837b9ed61a51a36c8383a2c0dc7eaa51b8d
   languageName: node
   linkType: hard
 
@@ -5422,7 +5422,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^5.42.1"
     "@typescript-eslint/parser": "npm:^5.42.1"
     "@vue/compiler-sfc": "npm:^3.2.45"
-    "@vue/runtime-dom": "npm:^3.2.45"
+    "@vue/runtime-dom": "npm:^3.2.37"
     axios: "npm:^1.1.3"
     bluebird: "npm:^3.7.2"
     body-parser: "npm:^1.20.1"


### PR DESCRIPTION
Reverts eve-val/eve-roster#1446

precautionary PR in case it goes badly like last time