### PR TITLE
Add support for statically-available Env vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
       "test/"
     ],
     "testEnvironment": "node",
-    "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "testRegex": "(\\.|/)(test|spec)\\.(jsx?|tsx?)$",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     }

--- a/src/infra/init/ExampleLegacyEnvReader.ts
+++ b/src/infra/init/ExampleLegacyEnvReader.ts
@@ -1,0 +1,29 @@
+import { getEnvLegacy } from "./Env.js";
+
+const savedEnv = getEnvLegacy();
+const savedCookieValue = getEnvLegacy().COOKIE_SECRET;
+
+/**
+ * An example class used to demonstrate how to write tests for old code that
+ * that reads env state via the legacy env mechanism.
+ *
+ * See its accompanying test for more info.
+ */
+export class ExampleLegacyEnvReader {
+  constructor() {
+    // Should really pass an instance of Env in here instead, but we have
+    // legacy users for whom the plumbing required would be impractical
+  }
+
+  getCookieSecret() {
+    return getEnvLegacy().COOKIE_SECRET;
+  }
+
+  getSavedCookieSecret() {
+    return savedCookieValue;
+  }
+}
+
+export function exampleFunctionThatDependsOnLegacyEnv() {
+  return `The hostname is ${savedEnv.HOSTNAME}`;
+}

--- a/src/infra/init/initMonitoring.ts
+++ b/src/infra/init/initMonitoring.ts
@@ -8,7 +8,6 @@ import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
 import { PgInstrumentation } from "@opentelemetry/instrumentation-pg";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
 import { Metadata, ChannelCredentials } from "@grpc/grpc-js";
-
 import { Env } from "./Env.js";
 
 export function initMonitoring(env: Env) {

--- a/test/infra/init/ExampleLegacyEnvReader.test.ts
+++ b/test/infra/init/ExampleLegacyEnvReader.test.ts
@@ -1,0 +1,37 @@
+import { mockModule } from "../../test_infra/mockModule";
+import { fakeEnvModule } from "./FakeEnv";
+
+// The line must appear above the ExampleLegacyEnvReader import (i.e. the class
+// under tests) in order for the faking to work properly.
+const fakeEnv = mockModule(
+  "src/infra/init/Env.js",
+  fakeEnvModule({
+    COOKIE_SECRET: "early_secret",
+  })
+);
+
+import {
+  exampleFunctionThatDependsOnLegacyEnv,
+  ExampleLegacyEnvReader,
+} from "../../../src/infra/init/ExampleLegacyEnvReader.js";
+
+test("New instance of reader properly gets faked values", () => {
+  fakeEnv.setEnv({
+    COOKIE_SECRET: "foo",
+  });
+
+  const reader = new ExampleLegacyEnvReader();
+
+  expect(reader.getCookieSecret()).toBe("foo");
+  expect(reader.getSavedCookieSecret()).toBe("early_secret");
+});
+
+test("Example global function properly reads fake hostname", () => {
+  fakeEnv.setEnv({
+    HOSTNAME: "some.fake.hostname",
+  });
+
+  expect(exampleFunctionThatDependsOnLegacyEnv()).toBe(
+    "The hostname is some.fake.hostname"
+  );
+});

--- a/test/infra/init/FakeEnv.ts
+++ b/test/infra/init/FakeEnv.ts
@@ -1,0 +1,59 @@
+import type * as EnvModule from "../../../src/infra/init/Env.js";
+import type { Env } from "../../../src/infra/init/Env.js";
+
+/**
+ * Builds a fake version of the Env module for use in testing.
+ *
+ * See ExampleLegacyEnvReader.test.ts for an example of usage.
+ */
+
+export function fakeEnvModule(props: Partial<Env> = {}) {
+  const fakeEnv = Object.assign({}, DEFAULT_ENV) as Writable<Env>;
+
+  const fakeModule = {
+    initEnv: () => fakeEnv,
+    getEnvLegacy: () => fakeEnv,
+    setEnv(props: Partial<Env>) {
+      Object.assign(fakeEnv, props);
+    },
+  };
+  fakeModule.setEnv(props);
+
+  return impersonateModule<typeof EnvModule, typeof fakeModule>(fakeModule);
+}
+
+const DEFAULT_ENV: Env = {
+  COOKIE_SECRET: "test_cookie_secret",
+  SSO_CLIENT_ID: "test_client_id",
+  SSO_SECRET_KEY: "test_sso_secret_key",
+  USER_AGENT: "test_user_agent",
+  DATABASE_URL: "",
+  DATABASE_HOST: "",
+  DATABASE_USER: "",
+  DATABASE_NAME: "",
+  DATABASE_PASS: "",
+  HOSTNAME: "test.example.com",
+  PORT: 0,
+  DOKKU_NGINX_PORT: 0,
+  DOKKU_PROXY_PORT: 0,
+  DOKKU_NGINX_SSL_PORT: 0,
+  DOKKU_PROXY_SSL_PORT: 0,
+  HONEYCOMB_API_KEY: "test_honeycomb_api_key",
+  HONEYCOMB_DATASET: "test_honeycomb_dataset",
+  DEBUG_GROUPS: [],
+  DEBUG_DISABLE_CRON: false,
+  isDevelopment: false,
+  isDev: false,
+  isTest: true,
+  isProduction: true,
+  isProd: true,
+};
+
+type Writable<T> = { -readonly [P in keyof T]: T[P] };
+
+function impersonateModule<M, F extends M>(fake: F) {
+  return {
+    ...fake,
+    __esModule: true,
+  };
+}

--- a/test/test_infra/mockModule.ts
+++ b/test/test_infra/mockModule.ts
@@ -1,0 +1,13 @@
+/**
+ * Wrapper around [jest.mock] that returns a typesafe instance of the mocked
+ * module.
+ *
+ * @param path The path of the module to mock, relative to the root of the
+ *    source tree, e.g. "src/foo/bar/baz" not "../../src/foo/bar/baz"
+ * @param implementation The mock or fake module to use instead of the real one
+ * @returns The implementation passed in
+ */
+export function mockModule<T>(path: string, implementation: T): T {
+  jest.mock(`../../${path}`, () => implementation);
+  return implementation;
+}

--- a/test/test_infra/wrapModule.ts
+++ b/test/test_infra/wrapModule.ts
@@ -1,0 +1,6 @@
+export function wrapModule<M>(fakeModule: M) {
+  return {
+    ...fakeModule,
+    __esModule: true,
+  };
+}


### PR DESCRIPTION
In general, we _should_ be explicitly injecting our env vars into the places that they need to go, but a bunch of legacy code is structured such that the plumbing necessary would be onerous.

Adds the getEnvLegacy() method that any module can call to get access to the global env vars. Also adds a fake implementation for tests. Figuring out how to fake out dependencies in Jest was not the most fun.