### PR TITLE
Migrate to importing jest globals in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "type": "module",
   "dependencies": {
     "@grpc/grpc-js": "^1.7.3",
+    "@jest/globals": "^29.3.1",
     "@opentelemetry/api": "1.3.0",
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.34.0",
@@ -74,7 +75,6 @@
     "@types/express": "^4.17.14",
     "@types/heapdump": "^0.3.1",
     "@types/imagemin": "^8.0.0",
-    "@types/jest": "^28.1.7",
     "@types/mini-css-extract-plugin": "^2.5.1",
     "@types/node": "^16.18.3",
     "@types/node-schedule": "^2.1.0",

--- a/test/infra/init/ExampleLegacyEnvReader.test.ts
+++ b/test/infra/init/ExampleLegacyEnvReader.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "@jest/globals";
 import { mockModule } from "../../test_infra/mockModule";
 import { fakeEnvModule } from "./FakeEnv";
 

--- a/test/test_infra/mockModule.ts
+++ b/test/test_infra/mockModule.ts
@@ -1,3 +1,5 @@
+import { jest } from "@jest/globals";
+
 /**
  * Wrapper around [jest.mock] that returns a typesafe instance of the mocked
  * module.

--- a/test/util/collection/ArrayQueue.test.ts
+++ b/test/util/collection/ArrayQueue.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "@jest/globals";
 import { ArrayQueue } from "../../../src/util/collection/ArrayQueue.js";
 
 test("Basic contents", () => {

--- a/test/util/sortBy.test.ts
+++ b/test/util/sortBy.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "@jest/globals";
 import {
   sortBy,
   cmpNumberProp,

--- a/test/util/time.test.ts
+++ b/test/util/time.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "@jest/globals";
 import * as time from "../../src/util/time.js";
 
 test("shortDurationString: output specificity = days", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,6 +139,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-plugin-utils@npm:^7.18.6":
+  version: 7.20.2
+  resolution: "@babel/helper-plugin-utils@npm:7.20.2"
+  checksum: 52745723617d3e4695a4dbec3728736c4f6d512ff382c36047b6d06117d2db059a65258629c5a42d57bed5eec2db7e473b14e524f611b0b04190b5922ea5d9f5
+  languageName: node
+  linkType: hard
+
 "@babel/helper-simple-access@npm:^7.17.7":
   version: 7.17.7
   resolution: "@babel/helper-simple-access@npm:7.17.7"
@@ -275,6 +282,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: d21aa96f15268f923f70e49155059ca220a7f7da3cec5072121fb8342527fc9e5753455cd61318054a170b1ecba13fd1891eb2c67f28a1c335af5bbaf52b93d0
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-jsx@npm:^7.7.2":
+  version: 7.18.6
+  resolution: "@babel/plugin-syntax-jsx@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.18.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 93aa8b4803ade912560529ffebed69cf29617f5025fdd39eeea3b2c60fa16f7120dee3e310931fd8faf14e2bd0bc5227210efea987bd393e61dcb4287d9aac8b
   languageName: node
   linkType: hard
 
@@ -646,12 +664,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/environment@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/environment@npm:29.3.1"
+  dependencies:
+    "@jest/fake-timers": "npm:^29.3.1"
+    "@jest/types": "npm:^29.3.1"
+    "@types/node": "npm:*"
+    jest-mock: "npm:^29.3.1"
+  checksum: 4d55705e76ad0998a1ee7c487d07d7c02641553d80e8e608d5b6d5965582179a1e71804d840b08aa1422c0f4e20854822af8245bc7a9e198b23dd37a85228807
+  languageName: node
+  linkType: hard
+
 "@jest/expect-utils@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/expect-utils@npm:28.1.3"
   dependencies:
     jest-get-type: "npm:^28.0.2"
   checksum: 1b33121844a68ab38bb06e19bc65e7e014a847ce57da1aa884850aecd78d6dd346c850945156b382491941f6b3b14fb0db1810b24643b73d5770667942f2b89a
+  languageName: node
+  linkType: hard
+
+"@jest/expect-utils@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/expect-utils@npm:29.3.1"
+  dependencies:
+    jest-get-type: "npm:^29.2.0"
+  checksum: b616f71d97331221c0ef1f3efefb5a23428a57e9fafd58ac1fda42516cbd327410f5f18ffa9f02d3f979d73bdbd78ddadb2066890dca1f316d59a79fc45024e1
   languageName: node
   linkType: hard
 
@@ -662,6 +701,16 @@ __metadata:
     expect: "npm:^28.1.3"
     jest-snapshot: "npm:^28.1.3"
   checksum: a8343c24d39160b4cee6776a721b0df51348c556946b059d52dd20d3e5b07b10be6c5905b897de17a8ec8b1b6646238186e729b91f27343db7b74b4f69459402
+  languageName: node
+  linkType: hard
+
+"@jest/expect@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/expect@npm:29.3.1"
+  dependencies:
+    expect: "npm:^29.3.1"
+    jest-snapshot: "npm:^29.3.1"
+  checksum: ecc46e47c9818a56f948a7b0d96f9a739798cf0baaf1c8c920df922d9670974563e99cdb53ed50629e32e4db82a05d1109c76fc381fcf1061e51a0745d8813d3
   languageName: node
   linkType: hard
 
@@ -679,6 +728,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/fake-timers@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/fake-timers@npm:29.3.1"
+  dependencies:
+    "@jest/types": "npm:^29.3.1"
+    "@sinonjs/fake-timers": "npm:^9.1.2"
+    "@types/node": "npm:*"
+    jest-message-util: "npm:^29.3.1"
+    jest-mock: "npm:^29.3.1"
+    jest-util: "npm:^29.3.1"
+  checksum: 951e8170ed56dc521bd6a2d6fece1dc91f9dc955fedfa71cbe8c8d334b6ebc5121e21ed86f065d0606e5b45de73aa651ae993a763281e74dc1d3a4d7174db4de
+  languageName: node
+  linkType: hard
+
 "@jest/globals@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/globals@npm:28.1.3"
@@ -687,6 +750,18 @@ __metadata:
     "@jest/expect": "npm:^28.1.3"
     "@jest/types": "npm:^28.1.3"
   checksum: 2dc23eb5a837b086cf828aecc3a43b443c7bc06d3c0a75a80fbc8ed4087e179d89690a608e2daa251f4ff1c5ec37d0e0388b0b68c1c97ef900501a376c14f2fd
+  languageName: node
+  linkType: hard
+
+"@jest/globals@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/globals@npm:29.3.1"
+  dependencies:
+    "@jest/environment": "npm:^29.3.1"
+    "@jest/expect": "npm:^29.3.1"
+    "@jest/types": "npm:^29.3.1"
+    jest-mock: "npm:^29.3.1"
+  checksum: 3484a6c6ecf25dfc40c9a401300decfea5185a5e4867f8a6d43adbcbbcd6af4e5e6637cbc647a179a37b269d2c646211418b01cbd331e0970c3d59004d47a781
   languageName: node
   linkType: hard
 
@@ -804,6 +879,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/transform@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/transform@npm:29.3.1"
+  dependencies:
+    "@babel/core": "npm:^7.11.6"
+    "@jest/types": "npm:^29.3.1"
+    "@jridgewell/trace-mapping": "npm:^0.3.15"
+    babel-plugin-istanbul: "npm:^6.1.1"
+    chalk: "npm:^4.0.0"
+    convert-source-map: "npm:^2.0.0"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    graceful-fs: "npm:^4.2.9"
+    jest-haste-map: "npm:^29.3.1"
+    jest-regex-util: "npm:^29.2.0"
+    jest-util: "npm:^29.3.1"
+    micromatch: "npm:^4.0.4"
+    pirates: "npm:^4.0.4"
+    slash: "npm:^3.0.0"
+    write-file-atomic: "npm:^4.0.1"
+  checksum: 574f94f38832c93f999a4d98507c17e4ca0fc6f1c66866503d80544aa0f6b6a0ecc3c256bfc9643320ce4120050e73afa8738f1309ed0dabf287a476752adf46
+  languageName: node
+  linkType: hard
+
 "@jest/types@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/types@npm:27.5.1"
@@ -845,6 +943,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/types@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/types@npm:29.3.1"
+  dependencies:
+    "@jest/schemas": "npm:^29.0.0"
+    "@types/istanbul-lib-coverage": "npm:^2.0.0"
+    "@types/istanbul-reports": "npm:^3.0.0"
+    "@types/node": "npm:*"
+    "@types/yargs": "npm:^17.0.8"
+    chalk: "npm:^4.0.0"
+  checksum: d22f39799b4a6e2e152f31dc9c9969b1581ac6561dd49cf22c63dc705d76976b338b2f431dc4e636419fd518f79f391878360741bc14bb452b8739bb45f7253d
+  languageName: node
+  linkType: hard
+
 "@jridgewell/gen-mapping@npm:^0.1.0":
   version: 0.1.1
   resolution: "@jridgewell/gen-mapping@npm:0.1.1"
@@ -863,6 +975,13 @@ __metadata:
     "@jridgewell/sourcemap-codec": "npm:^1.4.10"
     "@jridgewell/trace-mapping": "npm:^0.3.9"
   checksum: 67b84f3349f53caa7217735f2cd7d3687532dd525b160ca0717ca001bf4e5dde28401fabb8f41389fedfc83bd4437c71005ed409ab70a9bce1d1a37aa22d74ba
+  languageName: node
+  linkType: hard
+
+"@jridgewell/resolve-uri@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@jridgewell/resolve-uri@npm:3.1.0"
+  checksum: 6b641bb7e25bc92a9848898cc91a77a390f393f086297ec2336d911387bdd708919c418e74a22732cfc21d0e7300b94306f437d2e9de5ab58b33ebc6c39d6f9d
   languageName: node
   linkType: hard
 
@@ -890,6 +1009,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/sourcemap-codec@npm:1.4.14":
+  version: 1.4.14
+  resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
+  checksum: 2147ea75c966fed8a7d9ed6679b7e8c380fa790a9bea5a64f4ec1c26d24e44b461aa60fc3b228cea03a46708d9d1bcf19508035bf27ad5e8f63d0998ed1d1117
+  languageName: node
+  linkType: hard
+
 "@jridgewell/sourcemap-codec@npm:^1.4.10":
   version: 1.4.13
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.13"
@@ -904,6 +1030,16 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.0.3"
     "@jridgewell/sourcemap-codec": "npm:^1.4.10"
   checksum: 210642773f70bb3cf349ef237c08d6c70f456d19a4d1940acdbd1cffe67b29fe2742821028aeb63f9d26d203f44b1ab0d0ca6b326f0415230b79cfd3f0ccbd6a
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.15":
+  version: 0.3.17
+  resolution: "@jridgewell/trace-mapping@npm:0.3.17"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:3.1.0"
+    "@jridgewell/sourcemap-codec": "npm:1.4.14"
+  checksum: 388a2f604c1159dd29fdf3077c2a21fd2d322145f24cade868c0a7c55cfc993f3af82dd2e979438d9f06148c38af780abc7c0aa2eddbb34fab41698bb86d82e1
   languageName: node
   linkType: hard
 
@@ -1689,16 +1825,6 @@ __metadata:
   dependencies:
     "@types/istanbul-lib-report": "npm:*"
   checksum: fae0c472830b83744af363bb24b7a4dc3080ddbc885704955567bcd340948bfb01afbd347f1207ee508019d539faa487916ee2305806dfa1d67ad954db9c6b3a
-  languageName: node
-  linkType: hard
-
-"@types/jest@npm:^28.1.7":
-  version: 28.1.7
-  resolution: "@types/jest@npm:28.1.7"
-  dependencies:
-    expect: "npm:^28.0.0"
-    pretty-format: "npm:^28.0.0"
-  checksum: e463f4aeffc64ace59a146f3b288e3903d6feb241b34162729df9aac0790c2d98470a9884b3a60b224451441f756f77fbee5f56bd7eefda46a2b530e6c58fa86
   languageName: node
   linkType: hard
 
@@ -3742,6 +3868,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"convert-source-map@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "convert-source-map@npm:2.0.0"
+  checksum: 5a2bc5c8cbb87e36d9c33c541eccc1eb61480d72a1cda03ccaf00346479e788994ccbc80bd00874390a9a38c07b68f195991622f4ad8a5b791a0e90870e25450
+  languageName: node
+  linkType: hard
+
 "cookie-parser@npm:^1.4.6":
   version: 1.4.6
   resolution: "cookie-parser@npm:1.4.6"
@@ -4308,6 +4441,13 @@ __metadata:
   version: 28.1.1
   resolution: "diff-sequences@npm:28.1.1"
   checksum: eca298f10479b39a2ad2c0b6ba7a91ab86032c9298d7667cf1e95004930e57b904f7a1d5a037677ffbe51d83c7c52ea39b7ed3ddbeadc71bf65fd8acce8a813e
+  languageName: node
+  linkType: hard
+
+"diff-sequences@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "diff-sequences@npm:29.3.1"
+  checksum: af271add33f37490d21932cc11e8a72f7c05fba4187c8108bc8420c4091a0483fbe1f8e31c8c3bad8c069516f57cc73639bf89e67fe8874016de4cf0106f8d28
   languageName: node
   linkType: hard
 
@@ -4919,6 +5059,7 @@ __metadata:
   dependencies:
     "@babel/types": "npm:^7.20.5"
     "@grpc/grpc-js": "npm:^1.7.3"
+    "@jest/globals": "npm:^29.3.1"
     "@opentelemetry/api": "npm:1.3.0"
     "@opentelemetry/core": "npm:^1.8.0"
     "@opentelemetry/exporter-trace-otlp-grpc": "npm:^0.34.0"
@@ -4941,7 +5082,6 @@ __metadata:
     "@types/express": "npm:^4.17.14"
     "@types/heapdump": "npm:^0.3.1"
     "@types/imagemin": "npm:^8.0.0"
-    "@types/jest": "npm:^28.1.7"
     "@types/mini-css-extract-plugin": "npm:^2.5.1"
     "@types/node": "npm:^16.18.3"
     "@types/node-schedule": "npm:^2.1.0"
@@ -5094,7 +5234,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^28.0.0, expect@npm:^28.1.3":
+"expect@npm:^28.1.3":
   version: 28.1.3
   resolution: "expect@npm:28.1.3"
   dependencies:
@@ -5104,6 +5244,19 @@ __metadata:
     jest-message-util: "npm:^28.1.3"
     jest-util: "npm:^28.1.3"
   checksum: 902d161163d85c50908d70d12ef227f31392ac12ab2ff43b54d8247eee0e9ff9be403fcc77407a7f459126f3437d6020bebc1cbf2ddb0ce9ff7a0b83ad09c563
+  languageName: node
+  linkType: hard
+
+"expect@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "expect@npm:29.3.1"
+  dependencies:
+    "@jest/expect-utils": "npm:^29.3.1"
+    jest-get-type: "npm:^29.2.0"
+    jest-matcher-utils: "npm:^29.3.1"
+    jest-message-util: "npm:^29.3.1"
+    jest-util: "npm:^29.3.1"
+  checksum: bef5c2d537caf674da7a52d4b209949949ddeef8f6c8329ff115b60f6d4ee435515baa0abf13c16a98d8acf2b0898c28c1da092895d6239b2c9ffc1cb2e1bc4d
   languageName: node
   linkType: hard
 
@@ -5217,7 +5370,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0":
+"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: cc64810b004155f5ac29b208ebd5c862599a1a8aef3c4d27a34dfb694db7797e121dceda183507ec4a2a5413d9cb59521fd2540d0d00a5589ee6ea6bfac3c12e
@@ -6646,6 +6799,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-diff@npm:29.3.1"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    diff-sequences: "npm:^29.3.1"
+    jest-get-type: "npm:^29.2.0"
+    pretty-format: "npm:^29.3.1"
+  checksum: b0f9f48938638ca559abb7d3d70c06dd1f44b1f59e1b985614ce661383dd86dd26a92049ec59292438c2e60b98b5b68bc02dcd6365f4e9a725ba0f5cb0c3b91a
+  languageName: node
+  linkType: hard
+
 "jest-docblock@npm:^28.1.1":
   version: 28.1.1
   resolution: "jest-docblock@npm:28.1.1"
@@ -6696,6 +6861,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-get-type@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-get-type@npm:29.2.0"
+  checksum: bb688f6b906f79c93038ba1a1282f707e56b464d035dbe2b5143db35b1fb19a8a85440ec067e7ef44f29bcfac8cb5a7348321c806bea86957a5836b0d4ab9f22
+  languageName: node
+  linkType: hard
+
 "jest-haste-map@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-haste-map@npm:27.5.1"
@@ -6743,6 +6915,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-haste-map@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-haste-map@npm:29.3.1"
+  dependencies:
+    "@jest/types": "npm:^29.3.1"
+    "@types/graceful-fs": "npm:^4.1.3"
+    "@types/node": "npm:*"
+    anymatch: "npm:^3.0.3"
+    fb-watchman: "npm:^2.0.0"
+    fsevents: "npm:^2.3.2"
+    graceful-fs: "npm:^4.2.9"
+    jest-regex-util: "npm:^29.2.0"
+    jest-util: "npm:^29.3.1"
+    jest-worker: "npm:^29.3.1"
+    micromatch: "npm:^4.0.4"
+    walker: "npm:^1.0.8"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 264c34fd4b9bb5c84971a9c9d06bc75e14661b75afb995b298ec08a847f18cbedaec42efb3d5e6335e59f69629c42aceda77e4b64cb75d8d8344b39e5c5f26e4
+  languageName: node
+  linkType: hard
+
 "jest-leak-detector@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-leak-detector@npm:28.1.3"
@@ -6765,6 +6960,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-matcher-utils@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-matcher-utils@npm:29.3.1"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    jest-diff: "npm:^29.3.1"
+    jest-get-type: "npm:^29.2.0"
+    pretty-format: "npm:^29.3.1"
+  checksum: 936ae1fd9fe8a6d0dc31740740ad6cf3c698a16e232d57ee599e7e3040d22efc2063a7a744fb1b6550fb140b3ee7c5aeb46182920e37499e1ab4e2675ddce875
+  languageName: node
+  linkType: hard
+
 "jest-message-util@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-message-util@npm:28.1.3"
@@ -6782,6 +6989,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-message-util@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-message-util@npm:29.3.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.12.13"
+    "@jest/types": "npm:^29.3.1"
+    "@types/stack-utils": "npm:^2.0.0"
+    chalk: "npm:^4.0.0"
+    graceful-fs: "npm:^4.2.9"
+    micromatch: "npm:^4.0.4"
+    pretty-format: "npm:^29.3.1"
+    slash: "npm:^3.0.0"
+    stack-utils: "npm:^2.0.3"
+  checksum: e1afc9a0ab4fc6c54ae9f6dffe91b8beab433b513011c0bfe457f708109135f67b8e18e71fb41cdd919dc35d89128f59c64cf807db8506b38d30dbd3be605a80
+  languageName: node
+  linkType: hard
+
 "jest-mock@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-mock@npm:28.1.3"
@@ -6789,6 +7013,17 @@ __metadata:
     "@jest/types": "npm:^28.1.3"
     "@types/node": "npm:*"
   checksum: db7c9e8aaeb9702615fe886921457bdfbc7bbef84faf4ed6ebe0a4f612d6c6373796192dab9a784969338a05f72b3d164ee519f4859bfb9772faf626784371be
+  languageName: node
+  linkType: hard
+
+"jest-mock@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-mock@npm:29.3.1"
+  dependencies:
+    "@jest/types": "npm:^29.3.1"
+    "@types/node": "npm:*"
+    jest-util: "npm:^29.3.1"
+  checksum: fe8a9e41c88ec816b23ea7db16f9586c1265717e6ec043b12aed89c5ba8f2980e96f432236268484d8567c3f63c6b2a8097f2fb5e3f25b1b2e41a47efa1039c9
   languageName: node
   linkType: hard
 
@@ -6815,6 +7050,13 @@ __metadata:
   version: 28.0.2
   resolution: "jest-regex-util@npm:28.0.2"
   checksum: c461d2639cced2de7d061e96165071b8ec6d80fde5a867f48df8377c5572bf1a447b92b5d7275d7718ccc81d83d394f50e2afe1c7c93a2f5a3f9802f9814b3eb
+  languageName: node
+  linkType: hard
+
+"jest-regex-util@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-regex-util@npm:29.2.0"
+  checksum: d562a57097bac967caa16f70a2f63e60101dcb8cd82129bcd1669dc08346e5bdaf485c03746d918bc06d3d5a49c5fe7c2a9dcfd1e23f237d5d387a42630cbd99
   languageName: node
   linkType: hard
 
@@ -6963,6 +7205,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-snapshot@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-snapshot@npm:29.3.1"
+  dependencies:
+    "@babel/core": "npm:^7.11.6"
+    "@babel/generator": "npm:^7.7.2"
+    "@babel/plugin-syntax-jsx": "npm:^7.7.2"
+    "@babel/plugin-syntax-typescript": "npm:^7.7.2"
+    "@babel/traverse": "npm:^7.7.2"
+    "@babel/types": "npm:^7.3.3"
+    "@jest/expect-utils": "npm:^29.3.1"
+    "@jest/transform": "npm:^29.3.1"
+    "@jest/types": "npm:^29.3.1"
+    "@types/babel__traverse": "npm:^7.0.6"
+    "@types/prettier": "npm:^2.1.5"
+    babel-preset-current-node-syntax: "npm:^1.0.0"
+    chalk: "npm:^4.0.0"
+    expect: "npm:^29.3.1"
+    graceful-fs: "npm:^4.2.9"
+    jest-diff: "npm:^29.3.1"
+    jest-get-type: "npm:^29.2.0"
+    jest-haste-map: "npm:^29.3.1"
+    jest-matcher-utils: "npm:^29.3.1"
+    jest-message-util: "npm:^29.3.1"
+    jest-util: "npm:^29.3.1"
+    natural-compare: "npm:^1.4.0"
+    pretty-format: "npm:^29.3.1"
+    semver: "npm:^7.3.5"
+  checksum: e0dc071df9cb2bf72572dd37802ea1946d04ff4001229d804d3f280cda17b8868cd6e6aa635f4b7067440c623ffe64055fca7e4a81ad75ac722069b4f5532ad4
+  languageName: node
+  linkType: hard
+
 "jest-util@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-util@npm:27.5.1"
@@ -7002,6 +7276,20 @@ __metadata:
     graceful-fs: "npm:^4.2.9"
     picomatch: "npm:^2.2.3"
   checksum: d2bb747485b631ec2ba862c1aa181fc94df4e4591c481bf7af4fa6aeb1e3eee27a6e85a6067579a05f65a8ca6ce05e1189dd59edf1853a970239a388bcad23f2
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-util@npm:29.3.1"
+  dependencies:
+    "@jest/types": "npm:^29.3.1"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.0.0"
+    ci-info: "npm:^3.2.0"
+    graceful-fs: "npm:^4.2.9"
+    picomatch: "npm:^2.2.3"
+  checksum: c11f92ba490288788c921fcba2a173bf3a73c2573008faedaf227b8e42458816818753f228a3b5adcd52689c2086fb4e5b451db86a96bc673ae3c034a557cf7a
   languageName: node
   linkType: hard
 
@@ -7080,6 +7368,18 @@ __metadata:
     merge-stream: "npm:^2.0.0"
     supports-color: "npm:^8.0.0"
   checksum: 6feaeac250274c22e229a6b9bdc60e47e96310fd1d4726669aebe51bf3c8d3f4445c2901c8be0442a829b9b4730aeb5bf25255f8d05d73076b8558ac25f6cb6e
+  languageName: node
+  linkType: hard
+
+"jest-worker@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-worker@npm:29.3.1"
+  dependencies:
+    "@types/node": "npm:*"
+    jest-util: "npm:^29.3.1"
+    merge-stream: "npm:^2.0.0"
+    supports-color: "npm:^8.0.0"
+  checksum: 14ea04ab9eacd9dd7b5b6245032d9c043c6bad907a76bbfe0f09b3dde93992631df10e3f6463578e38a88812ab7c6edec6e343c3aad0e5378e1063ccc04b96ac
   languageName: node
   linkType: hard
 
@@ -9162,7 +9462,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^28.0.0, pretty-format@npm:^28.1.3":
+"pretty-format@npm:^28.1.3":
   version: 28.1.3
   resolution: "pretty-format@npm:28.1.3"
   dependencies:
@@ -9171,6 +9471,17 @@ __metadata:
     ansi-styles: "npm:^5.0.0"
     react-is: "npm:^18.0.0"
   checksum: 7ea80c810b87645bfb7a92736ea12588430ded3ec7833d158c438ec1d463c4187abb2ec1bb6efcd99fc6b81c2b786bb4ec7c29eee6f881595b0170fae702448e
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "pretty-format@npm:29.3.1"
+  dependencies:
+    "@jest/schemas": "npm:^29.0.0"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^18.0.0"
+  checksum: 503343a44ed74584c2e89fe3be6142636477b515179484b25ad3fe0b44f35d8a189cff3b002759d17c9751b1510dbbb4caa3e91ef3432c302de1c8aa78cde0f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Previously we were using @types/jest to make the jest methods available in tests, but this also made them available...everywhere, including non-test code. This moves to jest's new system where the core jest functions are manually imported.