### PR TITLE
Get client dev mode working again

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,10 @@
     ],
     "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     "no-redeclare": "off",
-    "no-dupe-class-members": "off"
+    "no-dupe-class-members": "off",
+    // @typescript-eslint recommends disabling this rule as it can't detect
+    // the presence of type globals
+    "no-undef": "off"
   },
   "env": {
     "browser": true,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@opentelemetry/sdk-node": "^0.37.0",
     "@opentelemetry/semantic-conventions": "^1.11.0",
     "@sentry/node": "^7.47.0",
+    "@types/pug": "^2.0.6",
     "axios": "^1.3.5",
     "bluebird": "^3.7.2",
     "body-parser": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "updatedb": "yarn node out/server/bin/updatedb.js",
     "clean": "rm -rf out/ && rm -rf static/dist/",
     "test": "jest",
-    "lint": "esprint",
-    "presubmit": "prettier --write --list-different . && esprint && jest",
+    "lint": "esprint check --workers=4",
+    "presubmit": "prettier --write --list-different . && yarn lint && jest",
     "ci-lint": "esprint check --workers=2",
     "ci-pretty-check": "prettier --check .",
     "postinstall": "patch -N -r - -p1 < patches/pnp-loader.patch > /dev/null || true"

--- a/src/bin/witness/RotatingFileLogWriter.ts
+++ b/src/bin/witness/RotatingFileLogWriter.ts
@@ -123,12 +123,11 @@ export class RotatingFileLogWriter extends Writable {
       if (err) {
         callback(err);
       } else {
+        console.log(outLine);
         if (!outLine.endsWith("\n")) {
           outLine += "\n";
         }
-        stream.write(outLine);
-        console.log(outLine);
-        callback();
+        stream.write(outLine, callback);
       }
     });
   }

--- a/src/infra/build-client/webpack.ts
+++ b/src/infra/build-client/webpack.ts
@@ -130,6 +130,7 @@ export function commonConfig(
         minify: false,
         chunks: ["main"],
       }),
+
       new HtmlWebpackPlugin({
         template: path.join(paths.clientSrc, "views/login.pug"),
         favicon: path.join(paths.clientSrc, "res/favicon.ico"),
@@ -137,6 +138,8 @@ export function commonConfig(
         minify: false,
         chunks: ["login"],
       }),
+
+      // Allows HtmlWebpackPlugin to understand pug templates
       new HtmlWebpackPugPlugin(),
 
       new ImageMinimizerPlugin({

--- a/src/infra/express/EndpointContext.ts
+++ b/src/infra/express/EndpointContext.ts
@@ -1,0 +1,18 @@
+import { Tnex } from "../../db/tnex/Tnex.js";
+import { Puggle } from "./puggle.js";
+
+/**
+ * A context object made avaiable to all express route handlers
+ *
+ * Available via req.app.locals.context
+ *
+ * Really we should be using dependency injection to get these in here, but
+ * here we are.
+ *
+ * Forgive me, lord of encapsulation, for creating this god object in mockery
+ * of your magnificence
+ */
+export interface EndpointContext {
+  db: Tnex;
+  puggle: Puggle;
+}

--- a/src/infra/express/protectedEndpoint.ts
+++ b/src/infra/express/protectedEndpoint.ts
@@ -22,6 +22,7 @@ import { SchemaVerificationError } from "../../util/express/schemaVerifier.js";
 import { fileURLToPath } from "url";
 import { buildLoggerFromFilename } from "../../infra/logging/buildLogger.js";
 import { getSession, endSession } from "./session.js";
+import { EndpointContext } from "./EndpointContext.js";
 
 const logger = buildLoggerFromFilename(fileURLToPath(import.meta.url));
 
@@ -71,7 +72,8 @@ export function htmlEndpoint<T extends object>(
         accountPrivs.account,
         accountPrivs.privs
       );
-      res.render(payload.template, payload.data);
+      const context = req.app.locals.context as EndpointContext;
+      await context.puggle.render(res, payload.template, payload.data);
     } catch (e) {
       if (!(e instanceof Error)) {
         throw e;

--- a/src/infra/express/puggle.ts
+++ b/src/infra/express/puggle.ts
@@ -1,0 +1,156 @@
+import path from "path";
+import fs from "fs";
+import fsPromises from "fs/promises";
+import pug from "pug";
+import express from "express";
+import webpack from "webpack";
+import { nil } from "../../util/simpleTypes.js";
+
+/**
+ * A wrapper around the pug templating engine that works with webpack dev
+ * middleware (if present).
+ *
+ * We use webpack to compile not only our JS and CSS files, but also our
+ * HTML files (which are actually Pug templates that generate HTML). This
+ * unfortunately means that we can't use express's standard Pug integration
+ * when rendering these HTML pages for one special reason: client dev mode.
+ * When in client dev mode, in order to improve performance, none of the
+ * webpack-compiled files are ever actually written to disk. However, express
+ * very much expects the HTML templates to be there and will throw an error if
+ * they're not.
+ *
+ * There is unfortunately no way to conditionally tell express to use the dev
+ * system's in-memory file system when looking for templates, so instead we
+ * have to bypass express's template system entirely and just manually render
+ * the HTML ourselves, reimplementing a cache system and more. Et voila,
+ * Puggle!
+ */
+export class Puggle {
+  private templateProvider: TemplateProvider;
+
+  constructor(outputPath: string, compiler: webpack.Compiler | nil) {
+    this.templateProvider = new TemplateProvider(
+      outputPath,
+      compiler != null
+        ? new DevMiddlewareTemplateFs(compiler)
+        : new ProdTemplateFs()
+    );
+  }
+
+  async render(res: express.Response, viewName: string, options: object) {
+    const template = await this.templateProvider.getTemplate(viewName);
+    res.status(200).send(template(options));
+  }
+}
+
+class TemplateProvider {
+  private cache = new Map<string, TemplateCacheEntry>();
+
+  constructor(private outputPath: string, private fs: TemplateFs) {}
+
+  async getTemplate(name: string): Promise<pug.compileTemplate> {
+    const cached = this.cache.get(name);
+
+    if (cached?.type == "pending") {
+      return cached.promise;
+    }
+
+    if (cached != null && (await this.fs.isCacheValid(cached))) {
+      return cached.template;
+    }
+
+    // Cache is invalid or missing; time to generate one
+    const promise = new Promise<pug.compileTemplate>(
+      // eslint-disable-next-line no-async-promise-executor
+      async (resolve, reject) => {
+        const filepath = path.join(this.outputPath, `${name}.pug`);
+        try {
+          const timestamp = Date.now();
+          const template = pug.compile(
+            await this.fs.readFile(filepath, "utf-8")
+          );
+          this.cache.set(name, {
+            type: "cached",
+            template,
+            filepath,
+            timestamp,
+          });
+          resolve(template);
+        } catch (e) {
+          reject(e);
+        }
+      }
+    );
+
+    this.cache.set(name, {
+      type: "pending",
+      promise: promise,
+    });
+
+    return promise;
+  }
+}
+
+class ProdTemplateFs implements TemplateFs {
+  isCacheValid(_cached: CachedTemplate): Promise<boolean> {
+    // Files can't change in prod, so the cache is always valid
+    return Promise.resolve(true);
+  }
+
+  readFile(filepath: string, encoding: BufferEncoding): Promise<string> {
+    return fsPromises.readFile(filepath, encoding);
+  }
+}
+
+class DevMiddlewareTemplateFs implements TemplateFs {
+  constructor(private compiler: webpack.Compiler) {}
+
+  async isCacheValid(cached: CachedTemplate): Promise<boolean> {
+    const stats = await this.lstat(cached.filepath);
+    return stats.mtimeMs < cached.timestamp;
+  }
+
+  readFile(filepath: string, encoding: BufferEncoding): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      (this.compiler.outputFileSystem.readFile as typeof fs.readFile)(
+        filepath,
+        encoding,
+        (err, data) => {
+          if (err) reject(err);
+          else resolve(data);
+        }
+      );
+    });
+  }
+
+  private lstat(filepath: string) {
+    return new Promise<fs.Stats>((resolve, reject) => {
+      (this.compiler.outputFileSystem.lstat as typeof fs.lstat)(
+        filepath,
+        (err, data) => {
+          if (err) reject(err);
+          else resolve(data);
+        }
+      );
+    });
+  }
+}
+
+type TemplateCacheEntry = PendingTemplate | CachedTemplate;
+
+interface PendingTemplate {
+  type: "pending";
+  promise: Promise<pug.compileTemplate>;
+}
+
+interface CachedTemplate {
+  type: "cached";
+  template: pug.compileTemplate;
+  filepath: string;
+  timestamp: number;
+}
+
+interface TemplateFs {
+  isCacheValid(cached: CachedTemplate): Promise<boolean>;
+  readFile(filepath: string, encoding: BufferEncoding): Promise<string>;
+}

--- a/src/infra/init/Env.ts
+++ b/src/infra/init/Env.ts
@@ -32,6 +32,12 @@ export function initEnv() {
     // Debugging flags
     DEBUG_GROUPS: jsonDebugGroups({ default: [] }),
     DEBUG_DISABLE_CRON: bool({ default: false }),
+
+    /**
+     * If true, dev server and hot reloading will be enabled for the frontend
+     * client. If false, you must build the client before starting the server.
+     */
+    CLIENT_DEV_MODE: bool({ default: false }),
   });
 
   if (cachedEnv != null) {

--- a/test/infra/init/FakeEnv.ts
+++ b/test/infra/init/FakeEnv.ts
@@ -42,6 +42,7 @@ const DEFAULT_ENV: Env = {
   HONEYCOMB_DATASET: "test_honeycomb_dataset",
   DEBUG_GROUPS: [],
   DEBUG_DISABLE_CRON: false,
+  CLIENT_DEV_MODE: false,
   isDevelopment: false,
   isDev: false,
   isTest: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3307,6 +3307,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/pug@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@types/pug@npm:2.0.6"
+  checksum: 78b5b53c0d80a756149a0ab6b92a2351eff73d25ded674189f972b2f9f78e8b4103c10a02ba95f9054b78af72e3b38284da77af7ee161d7c693e08176025670b
+  languageName: node
+  linkType: hard
+
 "@types/qs@npm:*":
   version: 6.9.7
   resolution: "@types/qs@npm:6.9.7"
@@ -6555,6 +6562,7 @@ __metadata:
     "@types/pg": "npm:^8.6.6"
     "@types/pg-pool": "npm:^2.0.3"
     "@types/progress-stream": "npm:^2.0.2"
+    "@types/pug": "npm:^2.0.6"
     "@types/serve-favicon": "npm:^2.5.3"
     "@types/source-map-support": "npm:^0.5.6"
     "@types/sqlite3": "npm:^3.1.8"


### PR DESCRIPTION
When we moved to using HtmlWebpackPlugin to build our pug/HTML templates, it broke our ability to serve those files when in dev mode. Because those files were now compiled by webpack, it meant they no longer existed while in dev mode (all webpack build artifacts are stored in an in-memory file system to increase performance). Express can't see those in-memory files, so it throws errors when you try to navigate to those pages.

The solution is, unfortunately, to completely bypass express's templating system and write our own, wrapping the pug system. Our system can conditionally read from the memory FS, allowing things to work properly both when in dev and prod modes.

Also introduces a new dev env flag, CLIENT_DEV_MODE that allows devs to disable client dev mode (presumably if you're just developing the server).