### PR TITLE
Fix rendering of ToolTip component

### DIFF
--- a/src/client/admin/AccountLog.vue
+++ b/src/client/admin/AccountLog.vue
@@ -30,7 +30,7 @@
             {{ row.relatedCharacterName }}
           </div>
           <div class="data">
-            <tool-tip v-if="row.data" gravity="right bottom" :inline="false">
+            <tool-tip v-if="row.data" gravity="bottom end">
               <template #default>
                 <div class="cell">{ ... }</div>
               </template>

--- a/src/client/dashboard/OwnedCharacterSlab.vue
+++ b/src/client/dashboard/OwnedCharacterSlab.vue
@@ -11,7 +11,7 @@
             :key="icon.key"
             class="status-icon"
             :inline="true"
-            gravity="center top"
+            gravity="top"
           >
             <template #default>
               <img class="status-icon-img" :src="icon.src" />

--- a/src/client/dev/DevPreview.vue
+++ b/src/client/dev/DevPreview.vue
@@ -37,6 +37,7 @@ import AppHeader from "../shared/AppHeader.vue";
 import DevLoadingSpinner from "./DevLoadingSpinner.vue";
 import DevOwnedCharacterSlab from "./DevOwnedCharacterSlab.vue";
 import DevTaskSlab from "./DevTaskSlab.vue";
+import DevToolTip from "./DevToolTip.vue";
 
 import { first } from "../../util/collections";
 
@@ -79,6 +80,11 @@ export default defineComponent({
           component: DevTaskSlab,
           label: "TaskSlab",
           path: "dev-task-slab",
+        },
+        {
+          component: DevToolTip,
+          label: "ToolTip",
+          path: "dev-tool-tip",
         },
       ],
     } as {

--- a/src/client/dev/DevToolTip.vue
+++ b/src/client/dev/DevToolTip.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="_dev-tooltip">
+    <div>
+      <div class="wrapper">
+        <tool-tip gravity="right" dev-force-open>
+          <template #default>
+            <div class="primaryContent">Primary content</div>
+          </template>
+          <template #message> This is a short message </template>
+        </tool-tip>
+      </div>
+
+      <div class="wrapper">
+        <tool-tip gravity="right" inline dev-force-open>
+          <template #default>
+            <div class="primaryContent">Primary content</div>
+          </template>
+          <template #message>
+            This is a much longer message that is intended to both fill the
+            maximum width and also eclipse the corresponding dimension of the
+            referent content.
+          </template>
+        </tool-tip>
+      </div>
+
+      <div class="wrapper">
+        <tool-tip gravity="left center" dev-force-open>
+          <template #default>
+            <div class="primaryContent">Primary content</div>
+          </template>
+          <template #message> This is a short message </template>
+        </tool-tip>
+      </div>
+
+      <div class="wrapper">
+        <tool-tip gravity="top" dev-force-open>
+          <template #default>
+            <div class="primaryContent">Primary content</div>
+          </template>
+          <template #message> This is a short message </template>
+        </tool-tip>
+      </div>
+
+      <div class="wrapper">
+        <tool-tip gravity="bottom center" dev-force-open>
+          <template #default>
+            <div class="primaryContent">Primary content</div>
+          </template>
+          <template #message> This is a short message </template>
+        </tool-tip>
+      </div>
+
+      <div class="wrapper">
+        <tool-tip gravity="top start" dev-force-open>
+          <template #default>
+            <div class="primaryContent">Primary content</div>
+          </template>
+          <template #message> This is a short message </template>
+        </tool-tip>
+      </div>
+
+      <div class="wrapper">
+        <tool-tip gravity="right end" dev-force-open>
+          <template #default>
+            <div class="primaryContent">Primary content</div>
+          </template>
+          <template #message>
+            This is a much longer message that is intended to both fill the
+            maximum width and also eclipse the corresponding dimension of the
+            referent content.
+          </template>
+        </tool-tip>
+      </div>
+
+      <div class="wrapper">
+        <tool-tip gravity="left start" dev-force-open>
+          <template #default>
+            <div class="tinyContent"></div>
+          </template>
+          <template #message>
+            This is a much longer message that is intended to both fill the
+            maximum width and also eclipse the corresponding dimension of the
+            referent content.
+          </template>
+        </tool-tip>
+      </div>
+
+      <div class="wrapper">
+        <tool-tip gravity="top center" inline dev-force-open>
+          <template #default>
+            <div class="inlineContent">123</div>
+          </template>
+          <template #message>
+            This is a much longer message that is intended to both fill the
+            maximum width and also eclipse the corresponding dimension of the
+            referent content.
+          </template>
+        </tool-tip>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import ToolTip from "../shared/ToolTip.vue";
+
+export default defineComponent({
+  components: {
+    ToolTip,
+  },
+});
+</script>
+
+<style scoped>
+.wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 500px;
+  height: 180px;
+}
+
+.primaryContent {
+  padding: 15px;
+  background-color: rgb(117, 92, 43);
+}
+
+.tinyContent {
+  width: 5px;
+  height: 5px;
+  background-color: #812424;
+}
+
+.inlineContent {
+  display: inline;
+  border: 1px solid red;
+}
+</style>

--- a/src/client/roster/CharacterRow.vue
+++ b/src/client/roster/CharacterRow.vue
@@ -2,7 +2,7 @@
   <div class="_character-row">
     <div class="horiz-aligner">
       <div class="alert col" :style="cellStyle(0)">
-        <tool-tip v-if="alertMessage != null" gravity="right" :inline="false">
+        <tool-tip v-if="alertMessage != null" gravity="top start">
           <template #default>
             <img class="alert-icon" :src="alertIconSrc" />
           </template>
@@ -26,7 +26,7 @@
             {{ displayVals[1] }}
           </template>
         </router-link>
-        <tool-tip v-if="!inPrimaryCorp" gravity="right" :inline="true">
+        <tool-tip v-if="!inPrimaryCorp" gravity="top" inline>
           <template #default>
             <eve-image
               :id="character.corporationId"
@@ -58,15 +58,13 @@
         <template v-if="!tooltipMessage(i + 3)">
           <span class="col-text">{{ dashDefault(dv) }}</span>
         </template>
-        <tool-tip v-else gravity="right" :inline="true">
-          <template #default>
-            <span
-              class="col-text"
-              :style="{ 'text-align': cellAlignment(i + 3) }"
-            >
-              {{ dashDefault(dv) }}
-            </span>
-          </template>
+        <tool-tip v-else gravity="top" inline>
+          <span
+            class="col-text"
+            :style="{ 'text-align': cellAlignment(i + 3) }"
+          >
+            {{ dashDefault(dv) }}
+          </span>
           <template #message>
             <span>{{ tooltipMessage(i + 3) }}</span>
           </template>
@@ -80,7 +78,6 @@
 import eveConstants from "../shared/eveConstants";
 import filter from "./filter";
 import { formatNumber } from "../shared/numberFormat";
-import { CssStyleObject } from "../shared/types";
 
 import EveImage from "../shared/EveImage.vue";
 import ToolTip from "../shared/ToolTip.vue";
@@ -97,7 +94,7 @@ const MSG_ICONS = [null, infoIcon, warningIcon, errorIcon] as const;
 
 type Value = string | number | boolean | null | undefined;
 
-import { defineComponent, PropType } from "vue";
+import { CSSProperties, defineComponent, PropType } from "vue";
 export default defineComponent({
   components: {
     EveImage,
@@ -182,7 +179,7 @@ export default defineComponent({
   },
 
   methods: {
-    cellStyle: function (idx: number): CssStyleObject {
+    cellStyle: function (idx: number): CSSProperties {
       let col = this.columns[idx];
       let paddingLeft = 0;
       let width = col.width;
@@ -266,9 +263,9 @@ export default defineComponent({
       }
     },
 
-    cellAlignment(colIdx: number): string {
+    cellAlignment(colIdx: number) {
       let col = this.columns[colIdx];
-      let align = "left";
+      let align: "left" | "center" | "right" = "left";
       if (col.key == "alertLevel") {
         align = "center";
       } else if (col.numeric) {
@@ -318,7 +315,6 @@ function altsLabel(altsCount: number): string {
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
-  display: block;
 }
 
 .alert {

--- a/src/client/shared/LoadingSpinner.vue
+++ b/src/client/shared/LoadingSpinner.vue
@@ -9,7 +9,7 @@
       />
       <tool-tip
         v-if="derivedState != 'spinning' && display == 'inline'"
-        :gravity="tooltipGravity || 'center top'"
+        :gravity="tooltipGravity || 'top'"
         style="vertical-align: text-bottom"
       >
         <template #default>

--- a/src/client/shared/types.ts
+++ b/src/client/shared/types.ts
@@ -6,8 +6,3 @@ export const SUPPORTED_TYPES = [
   "Render",
 ] as const;
 export type AssetType = (typeof SUPPORTED_TYPES)[number];
-
-type Dictionary<T> = { [key: string]: T };
-type Nullable<T> = T | null | undefined;
-export type CssStyleObject = Partial<CSSStyleDeclaration> &
-  Dictionary<Nullable<string>>;

--- a/src/client/srp/battles/BattleRow.vue
+++ b/src/client/srp/battles/BattleRow.vue
@@ -42,7 +42,7 @@ May also contain triage UI if triageMode is enabled.
           :key="member.id"
           class="participant"
         >
-          <tool-tip gravity="center top">
+          <tool-tip gravity="top">
             <template #default>
               <a
                 class="killmail-link"


### PR DESCRIPTION
- Rewrote most of ToolTip.vue component. Its approach was overly verbose and broke Chrome rendering somehow.
- Reworked ToolTip gravity API to use "primary + secondary" instead of "horizontal + vertical". The previous was difficult to remember and allowed for a nonsensical state ("center center"). The primary gravity option will work for most uses cases ("left"/"top"/"right"/"bottom") and can be optionally augmented with a secondary alignment ("start"/"center"/"end").
- Added a dev page for ToolTip
- Fixed a few other typing errors in related code.