### PR TITLE
Allow members to set their mains with no restriction

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,8 @@
       "error",
       { "argsIgnorePattern": "^_" }
     ],
-    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    // Covered by @typescript-eslint/no-unused-vars
+    "no-unused-vars": "off",
     "no-redeclare": "off",
     "no-dupe-class-members": "off",
     // @typescript-eslint recommends disabling this rule as it can't detect

--- a/src/domain/account/canDesignateMain.ts
+++ b/src/domain/account/canDesignateMain.ts
@@ -1,6 +1,12 @@
 import moment from "moment";
 
-const MODIFY_MAIN_WINDOW_DURATION = moment.duration(7, "days").asMilliseconds();
+// Originally we wanted to for main-changes outside of a certain window (7 days)
+// to require admin approval, but we never built the admin approval interface
+// and the security improvement appears to be minimal, so we'll disable this
+// for now.
+const MODIFY_MAIN_WINDOW_DURATION = moment
+  .duration(100, "years")
+  .asMilliseconds();
 
 export function canDesignateMain(accountCreated: number) {
   return Date.now() < accountCreated + MODIFY_MAIN_WINDOW_DURATION;


### PR DESCRIPTION
We were originally restricting this to a 7-day-from-account-creation window as a security measure, but the security concerns never really came to fruition.