### PR TITLE
Fix "Update SDE" task

### DIFF
--- a/src/server/eve/sde.ts
+++ b/src/server/eve/sde.ts
@@ -4,13 +4,22 @@ import {
   SdeSkill,
 } from "./sde/loadSdeSkillDefinitions.js";
 import { defaultSkillName } from "../domain/skills/defaultSkillName.js";
+import { Logger } from "../infra/logging/Logger.js";
 
 let skillDefinitions = new Map<number, SdeSkill>();
 
 export { SdeSkill } from "./sde/loadSdeSkillDefinitions.js";
 
-export async function loadStaticData(db: Tnex, strictMode: boolean) {
-  const _skillDefinitions = await loadSdeSkillDefinitions(db, strictMode);
+export async function loadStaticData(
+  db: Tnex,
+  strictMode: boolean,
+  logger: Logger | null = null
+) {
+  const _skillDefinitions = await loadSdeSkillDefinitions(
+    db,
+    strictMode,
+    logger
+  );
 
   skillDefinitions = _skillDefinitions;
 }

--- a/src/server/task-registry/runnableTasks.ts
+++ b/src/server/task-registry/runnableTasks.ts
@@ -14,6 +14,8 @@ import { truncateCronLog } from "../task/truncateCronLog.js";
 import { truncateCharacterLocations } from "../task/truncateCharacterLocations.js";
 import { updateSde } from "../task/updateSde.js";
 import { triagePendingLosses } from "../task/triagePendingLosses.js";
+import { updateSdeDryRun } from "../task/updateSdeDryRun.js";
+import { getEnv } from "../infra/init/Env.js";
 
 /**
  * List of tasks that can be manually invoked from the admin UI.
@@ -32,6 +34,11 @@ const TASKS: Task[] = [
   truncateCronLog,
   updateSde,
 ];
+
+if (getEnv().isDev) {
+  TASKS.push(updateSdeDryRun);
+}
+
 verifyTaskNamesAreUnique(TASKS);
 
 export function getRunnableTasks() {

--- a/src/server/task/updateSde/verifyImport.ts
+++ b/src/server/task/updateSde/verifyImport.ts
@@ -1,6 +1,7 @@
 import { Tnex } from "../../db/tnex/index.js";
 import * as sde from "../../eve/sde.js";
+import { Logger } from "../../infra/logging/Logger.js";
 
-export async function verifyImport(db: Tnex) {
-  await sde.loadStaticData(db, true /* strict mode */);
+export async function verifyImport(db: Tnex, logger: Logger) {
+  await sde.loadStaticData(db, true /* strict mode */, logger);
 }

--- a/src/server/task/updateSdeDryRun.ts
+++ b/src/server/task/updateSdeDryRun.ts
@@ -1,0 +1,17 @@
+import moment from "moment";
+import { Task } from "../infra/taskrunner/Task.js";
+import { Tnex } from "../db/tnex/index.js";
+import { JobLogger } from "../infra/taskrunner/Job.js";
+import { ingestSdeDryRun } from "./updateSde/ingestSde.js";
+
+export const updateSdeDryRun: Task = {
+  name: "updateSdeDryRun",
+  displayName: "Update SDE [Dry Run]",
+  description: "Parse but don't ingest the SDE from ./tmp/sqlite-latest.sqlite",
+  timeout: moment.duration(20, "minutes").asMilliseconds(),
+  executor,
+};
+
+async function executor(db: Tnex, job: JobLogger) {
+  await ingestSdeDryRun(job, db, "./tmp/sqlite-latest.sqlite");
+}

--- a/src/server/util/error.ts
+++ b/src/server/util/error.ts
@@ -1,0 +1,18 @@
+export function errorMessage(error: unknown) {
+  return error + "";
+}
+
+export function fullStackTrace(e: unknown) {
+  if (e instanceof Error) {
+    return errorToFullString(e);
+  }
+  return e + "";
+}
+
+function errorToFullString(e: Error) {
+  let message = e.stack || e.message;
+  if (e.cause) {
+    message += `\ncaused by:` + fullStackTrace(e.cause);
+  }
+  return message;
+}


### PR DESCRIPTION
Some newer skills have malformed skill requirements, which was causing the import to be rejected. Sigh. The system is already resilient to such problems, but added a way for us to allowlist known discrepancies.

Also added a special "dry run" version of the Update SDE task that is only available on dev builds. Instead of downloading the SDE from the web, it looks for it in tmp/ and doesn't actually commit any changes to the db. Useful when you're trying to figure out why the import is failing.