### PR TITLE
Fix up typings of LoadingSpinner and ToolTip

### DIFF
--- a/src/client/dashboard/PendingTransferSlab.vue
+++ b/src/client/dashboard/PendingTransferSlab.vue
@@ -12,14 +12,14 @@
           <div>
             <button
               class="roster-btn confirm-deny-btn"
-              :disabled="promise"
+              :disabled="promise != null"
               @click="transferCharacter"
             >
               Transfer character</button
             ><!--
         --><button
               class="roster-btn secondary confirm-deny-btn"
-              :disabled="promise"
+              :disabled="promise != null"
               @click="cancelTransfer"
             >
               Cancel

--- a/src/client/roster/CharacterRow.vue
+++ b/src/client/roster/CharacterRow.vue
@@ -2,7 +2,7 @@
   <div class="_character-row">
     <div class="horiz-aligner">
       <div class="alert col" :style="cellStyle(0)">
-        <tool-tip v-if="alertMessage != null" gravity="top start">
+        <tool-tip v-if="alertMessage != null" gravity="bottom start">
           <template #default>
             <img class="alert-icon" :src="alertIconSrc" />
           </template>
@@ -26,7 +26,7 @@
             {{ displayVals[1] }}
           </template>
         </router-link>
-        <tool-tip v-if="!inPrimaryCorp" gravity="top" inline>
+        <tool-tip v-if="!inPrimaryCorp" gravity="right">
           <template #default>
             <eve-image
               :id="character.corporationId"
@@ -58,7 +58,7 @@
         <template v-if="!tooltipMessage(i + 3)">
           <span class="col-text">{{ dashDefault(dv) }}</span>
         </template>
-        <tool-tip v-else gravity="top" inline>
+        <tool-tip v-else gravity="top">
           <span
             class="col-text"
             :style="{ 'text-align': cellAlignment(i + 3) }"

--- a/src/client/shared/ToolTipGravity.ts
+++ b/src/client/shared/ToolTipGravity.ts
@@ -1,0 +1,16 @@
+export enum ToolTipGravityPrimary {
+  LEFT = "left",
+  TOP = "top",
+  RIGHT = "right",
+  BOTTOM = "bottom",
+}
+
+export enum ToolTipGravitySecondary {
+  START = "start",
+  CENTER = "center",
+  END = "end",
+}
+
+export type ToolTipGravity =
+  | `${ToolTipGravityPrimary}`
+  | `${ToolTipGravityPrimary} ${ToolTipGravitySecondary}`;

--- a/src/client/shared/enumProp.ts
+++ b/src/client/shared/enumProp.ts
@@ -1,0 +1,31 @@
+import { PropType } from "vue";
+import { inEnum } from "../../shared/util/enum";
+
+export type EnumProp<T extends string> = `${T}`;
+
+export function enumProp<T extends StringEnum>(
+  enumType: T,
+  defaultValue: T[keyof T]
+) {
+  return {
+    type: String as PropType<EnumProp<T[keyof T]>>,
+    default: defaultValue,
+    validator: (value: string) => inEnum(value, enumType),
+  };
+}
+
+export function requiredEnumProp<T extends StringEnum>(
+  enumType: T,
+  defaultValue: T[keyof T]
+) {
+  return {
+    type: String as PropType<EnumProp<T[keyof T]>>,
+    default: defaultValue,
+    required: true as const,
+    validator: (value: string) => inEnum(value, enumType),
+  };
+}
+
+type StringEnum = {
+  [key: string]: string;
+};

--- a/src/shared/util/enum.ts
+++ b/src/shared/util/enum.ts
@@ -1,0 +1,40 @@
+/**
+ * Returns true if [value] is contained within [enumType].
+ */
+export function inEnum<T extends StringEnum>(
+  value: string,
+  enumType: T
+): boolean {
+  return findEnumValue(value, enumType, (foundValue) => foundValue != null);
+}
+
+/**
+ * If [value] is contained in [enumType], returns it. Otherwise returns
+ * [defaultVal].
+ */
+export function coerceToEnum<T extends StringEnum>(
+  value: string,
+  enumType: T,
+  defaultVal: T[keyof T]
+): T[keyof T] {
+  return findEnumValue(value, enumType, (foundValue) =>
+    foundValue != null ? foundValue : defaultVal
+  );
+}
+
+function findEnumValue<T extends StringEnum, R>(
+  value: string,
+  enumType: T,
+  processor: (value: T[keyof T] | null) => R
+) {
+  for (const key in enumType) {
+    if (enumType[key] == value) {
+      return processor(value as T[keyof T]);
+    }
+  }
+  return processor(null);
+}
+
+type StringEnum = {
+  [key: string]: string;
+};


### PR DESCRIPTION
Creates special handling for string enums as Vue properties. Also adjusts how tooltip renders its contents by default (defaults to inline now, rather than block).

The string enum solution is not ideal, but it's the best option right now until Typescript adds some extra type features for enums.