### PR TITLE
add workaround for hoshi

### DIFF
--- a/src/server/route/authenticate.ts
+++ b/src/server/route/authenticate.ts
@@ -209,6 +209,16 @@ async function authenticateChar(
           `You must create an account before you log in.`
         );
       } else {
+        // If ownerHash has been manually cleared, populate on login.
+        if (ownerHash == null) {
+          await dao.ownership.ownCharacter(
+            db,
+            charInfo.id,
+            owningAccount,
+            charInfo.ownerHash,
+            false
+          );
+        }
         authedAccount = owningAccount;
       }
       break;


### PR DESCRIPTION
to let hoshi log in after transferring eve accounts, needed to allow unsetting the owner id from ESI and re-setting it later.