### PR TITLE
Hotfix: only sync SRP for "full" member corporations

### DIFF
--- a/src/server/db/dao/ConfigDao.ts
+++ b/src/server/db/dao/ConfigDao.ts
@@ -127,4 +127,17 @@ export default class ConfigDao {
       .columns("groupTitle_title", "groupTitle_group")
       .run();
   }
+
+  getSrpMemberCorporations(db: Tnex) {
+    return db
+      .select(memberCorporation)
+      .where("mcorp_membership", "=", val("full"))
+      .columns(
+        "mcorp_corporationId",
+        "mcorp_membership",
+        "mcorp_name",
+        "mcorp_ticker"
+      )
+      .run();
+  }
 }

--- a/src/server/task/syncKillmails.ts
+++ b/src/server/task/syncKillmails.ts
@@ -23,7 +23,7 @@ export const syncKillmails: Task = {
   name: "syncKillmails",
   displayName: "Sync corp killmails",
   description: "Used to track SRP",
-  timeout: moment.duration(5, "minutes").asMilliseconds(),
+  timeout: moment.duration(20, "minutes").asMilliseconds(),
   executor,
 };
 
@@ -33,7 +33,7 @@ async function executor(db: Tnex, job: JobLogger) {
     "srpJurisdiction",
     "killmailSyncRanges"
   );
-  const memberCorps = await dao.config.getMemberCorporations(db);
+  const memberCorps = await dao.config.getSrpMemberCorporations(db);
 
   if (config.srpJurisdiction == null) {
     return;


### PR DESCRIPTION
This is a temporary hotfix that disables syncing SRP for affiliate corporations until we have a better UI that allows admins to select SRP status on a per-corporation basis.