### PR TITLE
Fail fast on empty refresh token

### DIFF
--- a/src/server/data-source/accessToken/TokenRefresher.ts
+++ b/src/server/data-source/accessToken/TokenRefresher.ts
@@ -62,6 +62,13 @@ export class TokenRefresher {
       errorType: null,
     };
 
+    if (!row.accessToken_refreshToken) {
+      // An empty refresh token means we don't currently have valid SSO for this
+      // character, and should not even attempt to refresh the access token.
+      result.errorType = AccessTokenErrorType.TOKEN_REFRESH_REJECTED;
+      return result;
+    }
+
     try {
       const response = await this._postRefreshRequest(
         row.accessToken_refreshToken


### PR DESCRIPTION
When using a refresh token to refresh an access token fails with an Unauthorized error code, we store an empty refresh token and indicate that the owner of the character needs to re-auth that character so we can get a fresh one. The problem is, we didn't check to see if the refresh token we were trying to refresh with was already empty, so any further API request results in us trying to refresh an access token with an empty refresh token, which is obviously not going to work.

This fix makes refreshAccessToken() fail fast if it's provided with an empty and thus invalid refresh token, instead of trying to hit CCP's endpoints with it.