### PR TITLE
Only warn() for ESI errors in syncSkills

### DIFF
--- a/src/server/task/syncSkills.ts
+++ b/src/server/task/syncSkills.ts
@@ -65,10 +65,10 @@ function executor(db: Tnex, job: JobLogger) {
         );
         const errorCount = characterIds.length - successCount;
         if (errorCount > 0) {
-          job.warn(
+          job.info(
             `Failed to update ${errorCount}/${characterIds.length}` +
               ` characters' skills {${esiFailureCount} ESI errors,` +
-              ` ${accessTokenFailureCount} access token errors.`
+              ` ${accessTokenFailureCount} access token errors}.`
           );
         }
       });


### PR DESCRIPTION
We expect not to be able to sync skills for characters missing access tokens; they are not a warning.