### PR TITLE
Don't warn for AccessTokenErrors

### DIFF
--- a/src/server/task/syncBorrowedShips.ts
+++ b/src/server/task/syncBorrowedShips.ts
@@ -233,13 +233,19 @@ async function executor(db: Tnex, job: JobLogger) {
     try {
       await updateCharacter(db, locCache, characterId);
     } catch (e) {
-      ++errors;
-      if (e instanceof AccessTokenError || isAnyEsiError(e)) {
+      if (e instanceof AccessTokenError) {
+        logger.info(
+          `Access token error while fetching ships for char ${characterId}.`,
+          e
+        );
+      } else if (isAnyEsiError(e)) {
+        ++errors;
         logger.warn(
           `ESI error while fetching ships for char ${characterId}.`,
           e
         );
       } else {
+        ++errors;
         throw e;
       }
     }

--- a/src/server/task/syncNotifications.ts
+++ b/src/server/task/syncNotifications.ts
@@ -93,13 +93,19 @@ async function executor(db: Tnex, job: JobLogger) {
       try {
         await updateCharacter(db, characterId);
       } catch (e) {
-        ++errors;
-        if (e instanceof AccessTokenError || isAnyEsiError(e)) {
+        if (e instanceof AccessTokenError) {
+          logger.info(
+            `Access token error while fetching notifications for char ${characterId}.`,
+            e
+          );
+        } else if (isAnyEsiError(e)) {
+          ++errors;
           logger.warn(
             `ESI error while fetching notifications for char ${characterId}.`,
             e
           );
         } else {
+          ++errors;
           throw e;
         }
       } finally {


### PR DESCRIPTION
ESI errors should be warnings but access token errors should not be.