### PR TITLE
Being unable to access a structure is expected sometimes

### DIFF
--- a/src/server/task/syncBorrowedShips.ts
+++ b/src/server/task/syncBorrowedShips.ts
@@ -65,7 +65,7 @@ class LocationCache {
         // If the character cannot access the structure, stop fetching names to
         // avoid running into ESI error limits.
         if (isAnyEsiError(e) && e.kind == EsiErrorKind.FORBIDDEN_ERROR) {
-          logger.warn(`unable to fetch location ${sid}: ${e.message}`);
+          logger.info(`unable to fetch location ${sid}: ${e.message}`);
           return;
         }
         // All other errors are unexpected, bubble them up.


### PR DESCRIPTION
This is info-level because it does not necessarily constitute a problem; we expect sometimes ships will wind up in structures to which someone doesn't have access and thus cannot resolve the name via API.