### PR TITLE
Mark refresh tokens invalid for 403s on expected scopes

### DIFF
--- a/src/server/task/syncBorrowedShips.ts
+++ b/src/server/task/syncBorrowedShips.ts
@@ -241,9 +241,9 @@ async function executor(db: Tnex, job: JobLogger) {
       } else if (isAnyEsiError(e)) {
         if (e.kind == EsiErrorKind.FORBIDDEN_ERROR) {
           logger.info(
-            `Marking access token as expired for char ${characterId} due to 403.`
+            `Marking access token as invalid for char ${characterId} due to 403.`
           );
-          dao.accessToken.markAsExpired(db, characterId);
+          dao.accessToken.markAsInvalid(db, characterId);
         }
         ++errors;
         logger.warn(

--- a/src/server/task/syncNotifications.ts
+++ b/src/server/task/syncNotifications.ts
@@ -102,9 +102,9 @@ async function executor(db: Tnex, job: JobLogger) {
         } else if (isAnyEsiError(e)) {
           if (e.kind == EsiErrorKind.FORBIDDEN_ERROR) {
             logger.info(
-              `Marking access token as expired for char ${characterId} due to 403.`
+              `Marking access token as invalid for char ${characterId} due to 403.`
             );
-            dao.accessToken.markAsExpired(db, characterId);
+            dao.accessToken.markAsInvalid(db, characterId);
           }
           ++errors;
           logger.warn(


### PR DESCRIPTION
Unlike 401 errors which imply we need to refresh the access token, 403 errors imply our current token doesn't allow us to read something we expected to, so we should stop trying and require a fresh authentication for that character before trying again.