### PR TITLE
Don't count 5xx errors for sync failures

### DIFF
--- a/src/server/task/syncBorrowedShips.ts
+++ b/src/server/task/syncBorrowedShips.ts
@@ -245,11 +245,19 @@ async function executor(db: Tnex, job: JobLogger) {
           );
           dao.accessToken.markAsInvalid(db, characterId);
         }
-        ++errors;
-        logger.warn(
-          `ESI error while fetching ships for char ${characterId}.`,
-          e
-        );
+        if (e.kind == EsiErrorKind.INTERNAL_SERVER_ERROR) {
+          // Don't consider ISEs to be noteworthy failures on our side
+          logger.info(
+            `ESI server error while fetching ships for char ${characterId}.`,
+            e
+          );
+        } else {
+          ++errors;
+          logger.warn(
+            `ESI error while fetching ships for char ${characterId}.`,
+            e
+          );
+        }
       } else {
         ++errors;
         throw e;


### PR DESCRIPTION
There's nothing we can particularly do to fix 5xx errors, so this makes us not count increment the failure count for borrowed ship syncing if we run into one, so the job won't show up as 'partial' success just because of a CCP-side issue.