### PR TITLE
cjs workaround?

### DIFF
--- a/src/server/infra/init/initMonitoring.ts
+++ b/src/server/infra/init/initMonitoring.ts
@@ -5,7 +5,8 @@ import * as opentelemetry from "@opentelemetry/sdk-node";
 import { Resource } from "@opentelemetry/resources";
 import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
+import exporter from "@opentelemetry/exporter-trace-otlp-grpc";
+const { OTLPTraceExporter } = exporter;
 import { Env } from "./Env.js";
 
 export function initMonitoring(env: Env) {


### PR DESCRIPTION
```
       [witness] Spawning child "/app/out/server/server.js"...
       [witness] Base logs path: /logs
       [witness] Opening log file /logs/roster_logs_2023-07-19.txt
       2023-07-19T22:23:01.529Z   225 U file:///app/out/server/infra/init/initMonitoring.js:8
       [witness] Child exited w/ code 1 and signal null
       2023-07-19T22:23:01.570Z   225 U import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
       2023-07-19T22:23:01.580Z   225 U          ^^^^^^^^^^^^^^^^^
       2023-07-19T22:23:01.581Z   225 U SyntaxError: Named export 'OTLPTraceExporter' not found. The requested module '@opentelemetry/exporter-trace-otlp-grpc' is a CommonJS module, which may not support all module.exports as named exports.
       2023-07-19T22:23:01.582Z   225 U CommonJS modules can always be imported via the default export, for example using:
       2023-07-19T22:23:01.583Z   225 U 
       2023-07-19T22:23:01.583Z   225 U import pkg from '@opentelemetry/exporter-trace-otlp-grpc';
       2023-07-19T22:23:01.584Z   225 U const { OTLPTraceExporter } = pkg;
       2023-07-19T22:23:01.585Z   225 U 
       2023-07-19T22:23:01.585Z   225 U     at ModuleJob._instantiate (node:internal/modules/esm/module_job:122:21)
       2023-07-19T22:23:01.586Z   225 U     at ModuleJob.run (node:internal/modules/esm/module_job:188:5)
       2023-07-19T22:23:01.586Z   225 U     at CustomizedModuleLoader.import (node:internal/modules/esm/loader:228:24)
       2023-07-19T22:23:01.587Z   225 U     at file:///app/src/server/server.ts:19:28
       [witness] Logs flushed
```