### PR TITLE
Cluster battle reports by alliance (rather than corp)

### DIFF
--- a/src/client/shared/EveImage.vue
+++ b/src/client/shared/EveImage.vue
@@ -6,14 +6,14 @@
 </template>
 
 <script lang="ts">
-import unknownIcon from "./res/EveImage-Unknown.svg";
-
+import { defineComponent, PropType } from "vue";
 import { SUPPORTED_TYPES, AssetType } from "./types";
+
+import unknownIcon from "./res/EveImage-Unknown.svg";
 
 const SUPPORTED_SIZES = [32, 64, 128, 256, 512] as const;
 type AssetSize = (typeof SUPPORTED_SIZES)[number];
 
-import { defineComponent, PropType } from "vue";
 export default defineComponent({
   props: {
     id: {
@@ -49,19 +49,37 @@ export default defineComponent({
       if (this.id == null || this.type == null) {
         return unknownIcon;
       } else {
+        const urlType = getUrlType(this.type);
         return (
           "//image.eveonline.com/" +
-          this.type +
+          urlType +
           "/" +
           this.id +
           "_" +
           this.requestSize +
-          (this.type == "Character" ? ".jpg" : ".png")
+          (urlType == "Character" ? ".jpg" : ".png")
         );
       }
     },
   },
 });
+
+function getUrlType(type: AssetType) {
+  switch (type) {
+    case "alliance":
+      return "Alliance";
+    case "corporation":
+      return "Corporation";
+    case "character":
+      return "Character";
+    case "type":
+      return "Type";
+    case "render":
+      return "Render";
+    default:
+      return type;
+  }
+}
 </script>
 
 <style scoped>

--- a/src/client/shared/types.ts
+++ b/src/client/shared/types.ts
@@ -1,8 +1,13 @@
 export const SUPPORTED_TYPES = [
   "Alliance",
+  "alliance",
   "Corporation",
+  "corporation",
   "Character",
+  "character",
   "Type",
+  "type",
   "Render",
+  "render",
 ] as const;
 export type AssetType = (typeof SUPPORTED_TYPES)[number];

--- a/src/client/srp/SrpTriplet.vue
+++ b/src/client/srp/SrpTriplet.vue
@@ -44,6 +44,8 @@ lines of text on the right. The text may be optionally wrapped in links.
 </template>
 
 <script lang="ts">
+import { defineComponent, PropType } from "vue";
+
 import AdaptiveLink from "./AdaptiveLink.vue";
 import EveImage from "../shared/EveImage.vue";
 import { AssetType } from "../shared/types";
@@ -52,7 +54,6 @@ import { NameCacheMixin } from "../shared/nameCache";
 
 const ABS_URL_PATTERN = /^(?:[a-z]+:)?\/\//i;
 
-import { defineComponent, PropType } from "vue";
 export default defineComponent({
   components: {
     AdaptiveLink,

--- a/src/client/srp/battles/BattleRow.vue
+++ b/src/client/srp/battles/BattleRow.vue
@@ -20,20 +20,14 @@ May also contain triage UI if triageMode is enabled.
       </div>
     </div>
 
-    <div
-      v-for="team in battle.teams"
-      :key="team.corporationId"
-      class="team-row"
-    >
+    <div v-for="team in battle.teams" :key="team.teamId" class="team-row">
       <srp-triplet
-        v-if="team.corporationId != 0"
+        v-if="team.teamId != 0"
         class="team-triplet"
-        :icon-id="team.corporationId"
-        :icon-type="'Corporation'"
-        :top-line="name(team.corporationId)"
-        :bottom-line="team.allianceId && name(team.allianceId)"
-        :default-href="zkillHref(team.corporationId, 'corporation')"
-        :bot-href="team.allianceId && zkillHref(team.allianceId, 'alliance')"
+        :icon-id="team.teamId"
+        :icon-type="team.type"
+        :top-line="name(team.teamId)"
+        :default-href="zkillHref(team.teamId, team.type)"
       />
       <div v-else class="empty-team">Unaffiliated</div>
       <div class="participant-cnt">
@@ -66,8 +60,8 @@ May also contain triage UI if triageMode is enabled.
                 class="hover-triplet"
                 :icon-id="member.characterId || member.shipId"
                 :icon-type="member.characterId ? 'Character' : 'Type'"
-                :top-line="name(member.characterId || member.shipId)"
-                :bottom-line="name(member.shipId)"
+                :top-line="nameOrUnknown(member.characterId ?? member.shipId)"
+                :bottom-line="nameOrUnknown(member.shipId)"
               />
             </template>
           </tool-tip>
@@ -84,7 +78,7 @@ May also contain triage UI if triageMode is enabled.
           class="srp-triplet"
           :icon-id="srp.shipType"
           :icon-type="'Type'"
-          :top-line="name(srp.victim)"
+          :top-line="nameOrUnknown(srp.victim)"
           :bottom-line="name(srp.shipType)"
           :default-href="zkillHref(srp.killmail, 'kill')"
         />
@@ -99,6 +93,8 @@ May also contain triage UI if triageMode is enabled.
 </template>
 
 <script lang="ts">
+import { defineComponent, PropType } from "vue";
+
 import EveImage from "../../shared/EveImage.vue";
 import SrpTriplet from "../SrpTriplet.vue";
 import SrpStatus from "../SrpStatus.vue";
@@ -107,7 +103,6 @@ import { NameCacheMixin } from "../../shared/nameCache";
 import { formatNumber } from "../../shared/numberFormat";
 import { BattleJson } from "../../../shared/route/api/srp/battle/battle_GET";
 
-import { defineComponent, PropType } from "vue";
 export default defineComponent({
   components: {
     EveImage,

--- a/src/shared/route/api/srp/battle/battle_GET.ts
+++ b/src/shared/route/api/srp/battle/battle_GET.ts
@@ -18,8 +18,10 @@ export interface BattleJson {
 }
 
 export interface Team {
+  teamId: number;
   corporationId: number | null;
   allianceId: number | null;
   members: Participant[];
   totalLosses: number;
+  type: "corporation" | "alliance" | "unaffiliated";
 }

--- a/src/shared/util/DefaultMap.ts
+++ b/src/shared/util/DefaultMap.ts
@@ -1,0 +1,31 @@
+import { nil } from "./simpleTypes.js";
+
+export class DefaultMap<K, V> extends Map<K, V> {
+  constructor(producer: (key: K) => V);
+  constructor(
+    producer: (key: K) => V,
+    iterable?: Iterable<readonly [K, V]> | nil,
+  );
+  constructor(
+    producer: (key: K) => V,
+    entries: readonly (readonly [K, V])[] | nil,
+  );
+  constructor(
+    private producer: (key: K) => V,
+    iterableOrEntries?:
+      | Iterable<readonly [K, V]>
+      | readonly (readonly [K, V])[]
+      | nil,
+  ) {
+    super(iterableOrEntries);
+  }
+
+  getOrInit(key: K): V {
+    let value = super.get(key);
+    if (value === undefined) {
+      value = this.producer(key);
+      this.set(key, value);
+    }
+    return value;
+  }
+}


### PR DESCRIPTION
When displaying battle reports, cluster killmails from the same alliance into one row. Previously we clustered by corporation, which led to visual noise.

Member corps are still pulled out into their own lines.