### PR TITLE
Focus on main character errors in overall list

### DIFF
--- a/src/client/roster/CharacterRow.vue
+++ b/src/client/roster/CharacterRow.vue
@@ -138,7 +138,10 @@ export default defineComponent({
       let level = 0;
       if (this.isMain) {
         level = Math.max(
-          this.account.alertLevel ?? 0,
+          Math.min(
+            this.account.alertLevel ?? 0,
+            2, // Non-main character errors shown up as warnings
+          ),
           this.character.alertLevel ?? 0,
         );
       } else {


### PR DESCRIPTION
Errors for non-main characters will only result in a warning indicator when viewing the top level list (but will be visible as errors when the main's row is expanded.