### PR TITLE
Revert "Focus on main character errors in overall list"

### DIFF
--- a/src/client/roster/CharacterRow.vue
+++ b/src/client/roster/CharacterRow.vue
@@ -138,10 +138,7 @@ export default defineComponent({
       let level = 0;
       if (this.isMain) {
         level = Math.max(
-          Math.min(
-            this.account.alertLevel ?? 0,
-            2, // Non-main character errors shown up as warnings
-          ),
+          this.account.alertLevel ?? 0,
           this.character.alertLevel ?? 0,
         );
       } else {


### PR DESCRIPTION
Reverts eve-val/eve-roster#2056. Turns out this code branch is actually dead and the max is calculated via the aggregate character functionality in RosterList.vue