### PR TITLE
fix: check if updateRows length > 0

### DIFF
--- a/src/server/task/syncKillmails/process/KillmailProcessor.ts
+++ b/src/server/task/syncKillmails/process/KillmailProcessor.ts
@@ -59,7 +59,9 @@ export class KillmailProcessor extends BatchedObjectWritable<ProcessedKillmail> 
       }
     }
 
-    await dao.killmail.updateKillmails(this._db, updateRows);
+    if (updateRows.length > 0) {
+      await dao.killmail.updateKillmails(this._db, updateRows);
+    }
 
     if (kmIds.length > 0) {
       await dao.srp.createSrpEntries(this._db, kmIds);


### PR DESCRIPTION
avoids crash inside KM processing if all KMs returned are already present & do not need modification

observability plan: https://ui.honeycomb.io/of-sound-mind/datasets/roster-production/result/qT7KKqNwSfy should start showing successes again.