### PR TITLE
Fix minor log display bug

### DIFF
--- a/src/server/route/api/admin/tasks/job_GET.ts
+++ b/src/server/route/api/admin/tasks/job_GET.ts
@@ -54,11 +54,11 @@ async function loadJobLog(
     const timestampMatch = LOG_LINE_PATTERN.exec(line);
     if (timestampMatch != null) {
       const lineStamp = moment(timestampMatch[1]);
+      if (end != null && lineStamp.isAfter(end)) {
+        break;
+      }
       if (lineStamp.isSameOrAfter(start)) {
         filteredLines.push(line);
-      }
-      if (end != null && lineStamp.isSameOrAfter(end)) {
-        break;
       }
     }
   }


### PR DESCRIPTION
Previously, final elements could get get off if they all shared the same timestamp.