### PR TITLE
Clean up a lot of error logging

### DIFF
--- a/src/server/data-source/esi/error.ts
+++ b/src/server/data-source/esi/error.ts
@@ -1,6 +1,4 @@
 import { EsiError, EsiErrorKind } from "./EsiError.js";
-import VError from "verror";
-import { inspect } from "util";
 
 export function isAnyEsiError(error: any): error is EsiError {
   return error instanceof EsiError;
@@ -24,12 +22,4 @@ export function isRetryableError(error: any): error is EsiError {
     (error.kind == EsiErrorKind.CLIENT_ERROR ||
       error.kind == EsiErrorKind.INTERNAL_SERVER_ERROR)
   );
-}
-
-export function printError(e: any) {
-  if (isAnyEsiError(e)) {
-    return VError.fullStack(e);
-  } else {
-    return inspect(e);
-  }
 }

--- a/src/server/data-source/esi/names.ts
+++ b/src/server/data-source/esi/names.ts
@@ -1,10 +1,11 @@
 import { SimpleNumMap, nil } from "../../../shared/util/simpleTypes.js";
-import { isAnyEsiError, printError } from "./error.js";
+import { isAnyEsiError } from "./error.js";
 import { UNKNOWN_CORPORATION_ID } from "../../db/constants.js";
 import { fileURLToPath } from "url";
 import { buildLoggerFromFilename } from "../../infra/logging/buildLogger.js";
 import { ESI_UNIVERSE_NAMES } from "./endpoints.js";
 import { fetchEsi } from "./fetch/fetchEsi.js";
+import { errorMessage } from "../../util/error.js";
 
 const logger = buildLoggerFromFilename(fileURLToPath(import.meta.url));
 
@@ -44,7 +45,7 @@ export async function fetchEveNames(ids: Iterable<number | nil>) {
         logger.error(
           "ESI error while fetching names for " + unresolvedIds.slice(i, end),
         );
-        logger.error(printError(e));
+        logger.error(errorMessage(e));
       }
     }
     i = end;

--- a/src/server/infra/logging/WitnessLogger.ts
+++ b/src/server/infra/logging/WitnessLogger.ts
@@ -1,7 +1,7 @@
 import { Logger, LogLevel } from "./Logger.js";
 import * as protocol from "../../bin/witness/protocol.js";
-import { printError } from "../../data-source/esi/error.js";
 import { nil } from "../../../shared/util/simpleTypes.js";
+import { stackTrace } from "../../util/error.js";
 
 export class WitnessLogger implements Logger {
   private _tag: string | nil;
@@ -38,7 +38,7 @@ export class WitnessLogger implements Logger {
     const levelTag = logLevelToProtocolTag(level);
     logMessage(levelTag, this._formatMessage(message, data));
     if (error) {
-      logMessage(levelTag, printError(error));
+      logMessage(levelTag, stackTrace(error));
     }
   }
 

--- a/src/server/task/syncRoster.ts
+++ b/src/server/task/syncRoster.ts
@@ -15,7 +15,7 @@ import {
   ESI_CORPORATIONS_$corporationId_ROLES,
   ESI_CORPORATIONS_$corporationId_MEMBERTRACKING,
 } from "../data-source/esi/endpoints.js";
-import { isAnyEsiError, printError } from "../data-source/esi/error.js";
+import { isAnyEsiError } from "../data-source/esi/error.js";
 import { hasRosterScopes } from "../domain/roster/hasRosterScopes.js";
 import { AccessTokenError } from "../data-source/accessToken/AccessTokenResult.js";
 import { AsyncReturnType } from "../../shared/util/simpleTypes.js";
@@ -24,6 +24,7 @@ import { LogLevel } from "../infra/logging/Logger.js";
 import { Task } from "../infra/taskrunner/Task.js";
 import { fetchEsi } from "../data-source/esi/fetch/fetchEsi.js";
 import { EsiScope } from "../data-source/esi/EsiScope.js";
+import { errorMessage } from "../util/error.js";
 
 /**
  * Updates the member list of each member corporation.
@@ -84,7 +85,7 @@ async function syncCorporation(
       }
       if (isAnyEsiError(e)) {
         job.warn(`ESI error while syncing via director ${row.character_name}:`);
-        job.warn(printError(e));
+        job.warn(errorMessage(e));
       } else if (e instanceof AccessTokenError) {
         job.info(
           `Token error while syncing via director ` +

--- a/src/server/task/updateSde/ingestSde.ts
+++ b/src/server/task/updateSde/ingestSde.ts
@@ -18,7 +18,7 @@ import {
   TYPE_CAPSULE,
   TYPE_CAPSULE_GENOLUTION,
 } from "../../eve/constants/types.js";
-import { errorMessage, fullStackTrace } from "../../util/error.js";
+import { errorMessage, stackTrace } from "../../util/error.js";
 import { LogLevel } from "../../infra/logging/Logger.js";
 
 const IMPORTER_VERSION = 0;
@@ -63,7 +63,7 @@ export async function ingestSdeDryRun(
     if (message == "Error: Dry run complete") {
       job.log(LogLevel.INFO, "Dry run complete");
     } else {
-      job.error(fullStackTrace(e));
+      job.error(stackTrace(e));
       throw e;
     }
   }

--- a/src/server/util/error.ts
+++ b/src/server/util/error.ts
@@ -1,18 +1,69 @@
-export function errorMessage(error: unknown) {
-  return error + "";
+import * as http from "http";
+import axios, { AxiosError } from "axios";
+import { VError } from "verror";
+
+export function errorMessage(e: unknown): string {
+  if (e instanceof VError) {
+    return e.message;
+  } else if (e instanceof Error) {
+    return e.cause != null
+      ? `${e.message}: ${errorMessage(e.cause)}`
+      : e.message;
+  } else if (typeof e == "string") {
+    return e;
+  } else {
+    return JSON.stringify(e);
+  }
 }
 
-export function fullStackTrace(e: unknown) {
-  if (e instanceof Error) {
-    return errorToFullString(e);
+export function stackTrace(e: unknown): string {
+  if (axios.isAxiosError(e)) {
+    return axiosErrorToString(e);
+  } else if (e instanceof VError) {
+    return VError.fullStack(e);
+  } else if (e instanceof Error) {
+    const thisStack = e.stack ?? e.message;
+    return e.cause != null
+      ? `${thisStack}\ncaused by: ${stackTrace(e.cause)}`
+      : thisStack;
+  } else {
+    return `Unknown error object: ${JSON.stringify(e)}`;
   }
-  return e + "";
 }
 
-function errorToFullString(e: Error) {
-  let message = e.stack ?? e.message;
-  if (e.cause) {
-    message += `\ncaused by:` + fullStackTrace(e.cause);
+/**
+ * Returns a simple error message for commonplace errors but a stack trace for
+ * unexpected ones.
+ */
+export function gentleStackTrace(e: unknown) {
+  // Add new entries here as desired
+  if (axios.isAxiosError(e)) {
+    return errorMessage(e);
+  } else {
+    return stackTrace(e);
   }
-  return message;
+}
+
+function axiosErrorToString(e: AxiosError<unknown, unknown>): string {
+  const message = [e.message];
+  if (e.request instanceof http.ClientRequest) {
+    const r = e.request;
+    message.push(`\n  Request:`);
+    message.push(`\n    ${r.method}: ${r.protocol}://${r.host}${r.path}`);
+  }
+  if (e.config) {
+    const c = e.config;
+    message.push(`\n    Headers: ${JSON.stringify(c.headers)}`);
+    if (c.data != null) {
+      message.push(`\n    Data: ${JSON.stringify(c.data)}`);
+    }
+  }
+  if (e.response) {
+    const r = e.response;
+    message.push(`\n  Response:`);
+    message.push(`\n    Status: ${r.status} ${r.statusText}`);
+    message.push(`\n    Data: ${JSON.stringify(r.data)}`);
+    message.push(`\n    Headers: ${JSON.stringify(r.headers)}`);
+  }
+  return message.join("");
 }


### PR DESCRIPTION
Centralizes our error-to-string pipelines into just two methods:

- errorMessage(e: unknown)
- stackTrace(e: unknown)

Both methods have specialized handling for VError, AxiosError, nested Errors, and non-error objects.

Updates many call sites to use the proper method (many, including the job scheduler, were just doing the Wrong Thing).