### PR TITLE
Change AccessTokenLoader to always use root DB connection

### DIFF
--- a/src/server/data-source/accessToken/AccessTokenLoader.ts
+++ b/src/server/data-source/accessToken/AccessTokenLoader.ts
@@ -509,7 +509,7 @@ class BatchedDbWriter {
   }
 
   writeEntry(db: Tnex, entry: LoadedCacheEntry) {
-    this.db = db;
+    this.db = db.root();
     this.pendingWrites.set(entry.characterId, {
       accessToken_character: entry.characterId,
       accessToken_refreshToken: entry.refreshToken,

--- a/src/server/db/tnex/TnexBuilder.ts
+++ b/src/server/db/tnex/TnexBuilder.ts
@@ -84,7 +84,6 @@ export class TnexBuilder {
     return new Tnex(
       knex,
       new Scoper(this._separator, this._tableToName, this._prefixToName),
-      knex,
     );
   }
 }

--- a/test/test_infra/db/FakeDb.ts
+++ b/test/test_infra/db/FakeDb.ts
@@ -26,4 +26,20 @@ export type FakeDb = Tnex & {
 
 class FakeDbWrapper {
   tables = new FakeDbTables();
+
+  asDb() {
+    return this as unknown as Tnex;
+  }
+
+  root() {
+    return this.asDb();
+  }
+
+  transaction<T>(callback: (db: Tnex) => Promise<T>): Promise<T> {
+    return callback(this.asDb());
+  }
+
+  asyncTransaction<T>(callback: (db: Tnex) => Promise<T>): Promise<T> {
+    return callback(this.asDb());
+  }
 }


### PR DESCRIPTION
Previously if the first DB object it was passed was a transaction, bad things would happen