### PR TITLE
Convert syncRoster to use runAsDirector()

### DIFF
--- a/src/server/data-source/accessToken/accessToken.ts
+++ b/src/server/data-source/accessToken/accessToken.ts
@@ -2,7 +2,11 @@ import { Tnex } from "../../db/tnex/index.js";
 import { getEnv } from "../../infra/init/Env.js";
 import { AccessTokenLoader } from "./AccessTokenLoader.js";
 import { checkNotNil } from "../../../shared/util/assert.js";
-import { AccessTokenError, TokenResultType } from "./AccessTokenResult.js";
+import {
+  AccessTokenError,
+  AccessTokenResult,
+  TokenResultType,
+} from "./AccessTokenResult.js";
 import { EsiScope } from "../esi/EsiScope.js";
 
 const tokenLoader = new AccessTokenLoader(getEnv());
@@ -26,6 +30,15 @@ export async function fetchAccessToken(
   } else {
     throw new AccessTokenError(result);
   }
+}
+
+export async function fetchAccessTokenResult(
+  db: Tnex,
+  characterId: number,
+  scopes: EsiScope[],
+): Promise<AccessTokenResult> {
+  const map = await tokenLoader.fetchAccessTokens(db, [characterId], scopes);
+  return checkNotNil(map.get(characterId));
 }
 
 /**

--- a/src/server/data-source/accessToken/runAsDirector.ts
+++ b/src/server/data-source/accessToken/runAsDirector.ts
@@ -1,0 +1,101 @@
+import { Tnex } from "../../db/tnex/Tnex.js";
+import { dao } from "../../db/dao.js";
+import { EsiEntity, esiChar as esiChar } from "../esi/EsiEntity.js";
+import { fetchAccessTokenResult } from "./accessToken.js";
+import { EsiScope } from "../esi/EsiScope.js";
+import {
+  AccessTokenResult,
+  TokenResultType,
+  accessTokenResultToString,
+} from "./AccessTokenResult.js";
+import { isAnyEsiError } from "../esi/error.js";
+import { EsiErrorKind } from "../esi/EsiError.js";
+import { Logger } from "../../infra/logging/Logger.js";
+import { Result, failure, success } from "../../util/Result.js";
+
+/**
+ * Given a corporation, retrives a director's access token and runs [executor].
+ * Iterates through directors until it finds one with sufficient access scopes
+ * to perform the action.
+ *
+ * In most cases, if [executor] throws an error, execution will cease and the
+ * the error will be propagated upwards to the caller of this function.
+ * However, if the thrown error is an EsiError with kind FORBIDDEN_ERROR,
+ * [executor] will be called again with the next valid director's token. This
+ * behavior exists to address situations where a character has recently lost
+ * the director role but that information has not yet been propagated to our
+ * systems (in particular, because the job task that does so requires director
+ * tokens to function).
+ */
+export async function runAsDirector<T>(
+  db: Tnex,
+  log: Logger,
+  corp: EsiEntity,
+  requiredScopes: EsiScope[],
+  executor: (token: string, director: EsiEntity) => T | Promise<T>,
+): Promise<T> {
+  return (
+    await tryAsDirector(db, log, corp, requiredScopes, executor)
+  ).unwrap();
+}
+
+/**
+ * The same as {@link runAsDirector}, but returns a {@link Result} rather than
+ * throwing an error if execution fails.
+ */
+export async function tryAsDirector<T>(
+  db: Tnex,
+  log: Logger,
+  corp: EsiEntity,
+  requiredScopes: EsiScope[],
+  executor: (token: string, director: EsiEntity) => T | Promise<T>,
+): Promise<Result<T>> {
+  const directorRows = await dao.roster.getCorpDirectors(db, corp.id);
+
+  const tokenResults: [EsiEntity, AccessTokenResult, boolean][] = [];
+
+  for (const row of directorRows) {
+    const director = esiChar(row.character_id, row.character_name);
+    const tokenResult = await fetchAccessTokenResult(
+      db,
+      director.id,
+      requiredScopes,
+    );
+    tokenResults.push([director, tokenResult, false]);
+    if (tokenResult.kind != TokenResultType.SUCCESS) {
+      continue;
+    }
+    try {
+      return success(await executor(tokenResult.token, director));
+    } catch (e) {
+      if (isAnyEsiError(e) && e.kind == EsiErrorKind.FORBIDDEN_ERROR) {
+        log.error(
+          `FORBIDDEN error while executing job on behalf of director` +
+            ` ${director} for ${corp}`,
+          e,
+        );
+        tokenResults[tokenResults.length - 1][2] = true;
+        continue;
+      } else {
+        return failure(e);
+      }
+    }
+  }
+
+  const messages: string[] = [];
+  for (const [director, result, wasForbidden] of tokenResults) {
+    let message = `${director}: ${accessTokenResultToString(result)}`;
+    if (wasForbidden) {
+      message += ` (*threw forbidden error)`;
+    }
+    messages.push(message);
+  }
+  let errorMessage =
+    `No valid director tokens to complete action.` +
+    ` (${messages.length} total)`;
+  if (messages.length > 0) {
+    errorMessage += `\n${messages.join("\n")}`;
+  }
+
+  return failure(new Error(errorMessage));
+}

--- a/src/server/data-source/esi/EsiEntity.ts
+++ b/src/server/data-source/esi/EsiEntity.ts
@@ -7,7 +7,7 @@ export class EsiEntity {
   ) {}
 
   toString(): string {
-    return `{ ${this.name}, ${this.id} }"`;
+    return `{ ${this.name}, ${this.id} }`;
   }
 
   [util.inspect.custom](
@@ -17,4 +17,12 @@ export class EsiEntity {
   ) {
     return this.toString();
   }
+}
+
+export function esiChar(id: number, name: string) {
+  return new EsiEntity(id, name);
+}
+
+export function esiCorp(id: number, name: string) {
+  return new EsiEntity(id, name);
 }

--- a/src/server/db/dao/RosterDao.ts
+++ b/src/server/db/dao/RosterDao.ts
@@ -191,12 +191,7 @@ export default class RosterDao {
       .join(t.accessToken, "accessToken_character", "=", "character_id")
       .where("character_corporationId", "=", val(corporation))
       .whereContains("character_roles", "@>", ["Director"])
-      .columns(
-        "character_id",
-        "character_name",
-        "accessToken_scopes",
-        "accessToken_needsUpdate",
-      )
+      .columns("character_id", "character_name")
       .run();
   }
 

--- a/src/server/util/Result.ts
+++ b/src/server/util/Result.ts
@@ -1,0 +1,54 @@
+export type Result<T> = SuccessResult<T> | ErrorResult<T>;
+
+export class BaseResult<T> {
+  private sentinel: T | undefined;
+
+  constructor(public readonly kind: "success" | "error") {}
+
+  isSuccess(): this is SuccessResult<T> {
+    return this.kind == "success";
+  }
+
+  isError(): this is ErrorResult<T> {
+    return this.kind == "error";
+  }
+
+  unwrap(): T {
+    if (this.isSuccess()) {
+      return this.value;
+    } else if (this.isError()) {
+      throw this.error;
+    }
+    {
+      throw new Error(`This should never happen`);
+    }
+  }
+
+  static success<T>(value: T) {
+    return new SuccessResult(value);
+  }
+
+  static error<T>(error: unknown) {
+    return new ErrorResult<T>(error);
+  }
+}
+
+class SuccessResult<T> extends BaseResult<T> {
+  constructor(public readonly value: T) {
+    super("success");
+  }
+}
+
+class ErrorResult<T> extends BaseResult<T> {
+  constructor(public readonly error: unknown) {
+    super("error");
+  }
+}
+
+export function success<T>(value: T): Result<T> {
+  return new SuccessResult<T>(value);
+}
+
+export function failure<T>(error: unknown): Result<T> {
+  return new ErrorResult<T>(error);
+}


### PR DESCRIPTION
Intruduces runAsDirector(), a new method that allows jobs to safely attempt to run a task using an arbitary corporation director's access tokens. Supports retrying across multiple directors for multiply-redundant behavior.