### PR TITLE
Implement fetchAverageMarketPrices

### DIFF
--- a/src/server/data-source/esi/endpoints.ts
+++ b/src/server/data-source/esi/endpoints.ts
@@ -304,6 +304,17 @@ export const ESI_MARKETS_$regionId_ORDERS = {
   }[],
 };
 
+export const ESI_MARKETS_PRICES = {
+  method: FetchMethod.GET,
+  path: "/v1/markets/prices/",
+  access: Public.ACCESS,
+  response: [] as {
+    adjusted_price: number;
+    average_price: number;
+    type_id: number;
+  }[],
+};
+
 export const ESI_UI_OPENWINDOW_INFORMATION = {
   method: FetchMethod.POST,
   path: "/v1/ui/openwindow/information/",

--- a/src/server/data-source/esi/market/fetchAverageMarketPrices.ts
+++ b/src/server/data-source/esi/market/fetchAverageMarketPrices.ts
@@ -1,0 +1,115 @@
+import moment from "moment";
+
+import { clock } from "../../../util/wrapped/clock.js";
+import { ESI_MARKETS_PRICES } from "../endpoints.js";
+import { fetchEsi } from "../fetch/fetchEsi.js";
+import { buildLogger } from "../../../infra/logging/buildLogger.js";
+
+const logger = buildLogger("fetchAverageMarketPrices");
+
+/**
+ * Looks up the average market prices of items
+ *
+ * Uses ESI's definition of "average price", which is a 30-day rolling average
+ * of all prices across the galaxy. When available, uses the adjusted_price
+ * version, which CCP has designed to be more resistant to manipulation.
+ * Otherwise, uses the pure average.
+ *
+ * This request is cached for about 1 hour; successive requests are very fast.
+ *
+ * @param typeIds The items to look up prices for
+ * @param requireFresh If true, throw an error if we've failed to update prices
+ *   recently. If false, return the previously-cached version (which may be 0).
+ * @returns A Map from typeId to price. This map is guaranteed to contain an
+ *   an entry for each orginal typeId, although the price may be zero. In
+ *   particular, items that cannot be sold on the market (such as civilian
+ *   modules) will always have a price of zero.
+ */
+export function fetchAverageMarketPrices(
+  typeIds: number[],
+  requireFresh = false,
+) {
+  return INSTANCE.fetchAverageMarketPrices(typeIds, requireFresh);
+}
+
+class MarketPriceCache {
+  private readonly priceMap = new Map<number, number>();
+  private fetchStats = {
+    attemptedCount: 0,
+    attemptedTimestamp: 0,
+    successfulTimestamp: 0,
+  };
+  private fetchPromise: Promise<void> | null = null;
+
+  async fetchAverageMarketPrices(typeIds: number[], requireFresh: boolean) {
+    if (this.cacheNeedsRefresh()) {
+      try {
+        await this.refreshPriceCache();
+      } catch (e) {
+        if (requireFresh) {
+          throw e;
+        }
+      }
+    }
+    const resultMap = new Map<number, number>();
+    for (const typeId of typeIds) {
+      resultMap.set(typeId, this.priceMap.get(typeId) ?? 0);
+    }
+    return resultMap;
+  }
+
+  private cacheNeedsRefresh() {
+    const now = clock.now();
+    return (
+      now - this.fetchStats.successfulTimestamp >= PRICE_CACHE_DURATION &&
+      (now - this.fetchStats.attemptedTimestamp >= RETRY_TIMEOUT_WINDOW ||
+        this.fetchStats.attemptedCount < MAX_ATTEMPTS)
+    );
+  }
+
+  private refreshPriceCache() {
+    if (this.fetchPromise == null) {
+      this.fetchPromise = this.refreshPriceCacheInner().then((value) => {
+        this.fetchPromise = null;
+        return value;
+      });
+    }
+    return this.fetchPromise;
+  }
+
+  private async refreshPriceCacheInner(): Promise<void> {
+    const fetchTime = clock.now();
+    this.fetchStats.attemptedTimestamp = fetchTime;
+    this.fetchStats.attemptedCount++;
+
+    let result;
+    try {
+      result = await fetchEsi(ESI_MARKETS_PRICES, {});
+    } catch (e) {
+      const error = new Error(
+        `Error while trying to fetch global market prices`,
+        { cause: e },
+      );
+      logger.error(error.message, error);
+      throw error;
+    }
+
+    for (const entry of result) {
+      // Use adjusted_price where it's present, but in the (inexplicable) cases
+      // where it's zero, fall back to average_price
+      this.priceMap.set(
+        entry.type_id,
+        entry.adjusted_price || entry.average_price,
+      );
+    }
+    logger.info(`Updated ${result.length} market prices`);
+    this.fetchStats.successfulTimestamp = fetchTime;
+    this.fetchStats.attemptedCount = 0;
+  }
+}
+
+const INSTANCE = new MarketPriceCache();
+
+const PRICE_CACHE_DURATION = moment.duration(3630, "seconds").asMilliseconds();
+const RETRY_TIMEOUT_WINDOW = moment.duration(60, "seconds").asMilliseconds();
+const MAX_ATTEMPTS = 2;

--- a/src/server/data-source/esi/market/fetchJitaSellPrices.ts
+++ b/src/server/data-source/esi/market/fetchJitaSellPrices.ts
@@ -1,11 +1,11 @@
 import moment from "moment";
 
-import { ExpirationCache } from "../../util/ExpirationCache.js";
+import { ExpirationCache } from "../../../util/ExpirationCache.js";
 import { fetchMarketStats } from "./fetchMarketStats.js";
 import {
   REGION_THE_FORGE,
   SYSTEM_JITA,
-} from "../../eve/constants/mapSolarSystems.js";
+} from "../../../eve/constants/mapSolarSystems.js";
 
 const CACHE = new ExpirationCache<number, number>();
 const CACHE_DURATION = moment.duration(4, "hours").asMilliseconds();

--- a/src/server/data-source/esi/market/fetchMarketStats.ts
+++ b/src/server/data-source/esi/market/fetchMarketStats.ts
@@ -1,11 +1,11 @@
 import { default as axios } from "axios";
 import { inspect } from "util";
-import { ESI_MARKETS_$regionId_ORDERS } from "../esi/endpoints.js";
-import { fetchEsiEx } from "../esi/fetch/fetchEsi.js";
+import { ESI_MARKETS_$regionId_ORDERS } from "../endpoints.js";
+import { fetchEsiEx } from "../fetch/fetchEsi.js";
 import { fileURLToPath } from "url";
-import { buildLoggerFromFilename } from "../../infra/logging/buildLogger.js";
-import { streamParallelJobs } from "../../util/asyncUtil.js";
-import { isAnyEsiError } from "../esi/error.js";
+import { buildLoggerFromFilename } from "../../../infra/logging/buildLogger.js";
+import { streamParallelJobs } from "../../../util/asyncUtil.js";
+import { isAnyEsiError } from "../error.js";
 
 const logger = buildLoggerFromFilename(fileURLToPath(import.meta.url));
 

--- a/src/server/domain/srp/triage/payout.ts
+++ b/src/server/domain/srp/triage/payout.ts
@@ -1,6 +1,6 @@
 import { ZKillmail } from "../../../data-source/zkillboard/ZKillmail.js";
 import { ApprovedVerdict, MarketPayout } from "./TriageRule.js";
-import { fetchJitaSellPrices } from "../../../data-source/evemarketer/fetchJitaSellPrices.js";
+import { fetchJitaSellPrices } from "../../../data-source/esi/market/fetchJitaSellPrices.js";
 import { SrpVerdictStatus } from "../../../db/dao/enums.js";
 import { TriagedLoss } from "./triageLosses.js";
 


### PR DESCRIPTION
Previously we were using fetchJitaSellPrices, which we still maintain, but honestly we should probably just use the galactic average, which CCP provides a very efficient and convenient endpoint for.

Adds fetchAverageMarketPrices, which does just that. It caches and coalesces requests and is just generally quite fast. It stores all ~15k market prices in memory, but that's probably fine.